### PR TITLE
fix: order of package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
     "email": "rebecca.stevens@outlook.co.nz"
   },
   "exports": {
-    "default": "./lib/index.cjs",
     "import": "./lib/index.mjs",
-    "require": "./lib/index.cjs"
+    "require": "./lib/index.cjs",
+    "default": "./lib/index.cjs"
   },
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",


### PR DESCRIPTION
Hi,

Thanks for making this library. 

I was getting an error using this in a Next.js project:

>Module not found: Default condition should be last one

I think it's Webpack related, but I'm not really sure exactly.

Anyway, reordering the exports in package.json resolves it.