### PR TITLE
fix: add better support for readonly types

### DIFF
--- a/docs/deepmergeCustom.md
+++ b/docs/deepmergeCustom.md
@@ -37,7 +37,7 @@ This can be done using [Declaration Merging](https://www.typescriptlang.org/docs
 
 ```ts
 declare module "deepmerge-ts" {
-  interface DeepMergeMergeFunctionURItoKind<Ts extends ReadonlyArray<unknown>, MF extends DeepMergeMergeFunctionsURIs> {
+  interface DeepMergeMergeFunctionURItoKind<Ts extends Readonly<ReadonlyArray<unknown>>, MF extends DeepMergeMergeFunctionsURIs> {
     readonly MyCustomMergeURI: MyValue;
   }
 }
@@ -70,17 +70,16 @@ customDeepmerge(x, y, z); // => { foo: [Date, Date, Date] }
 
 declare module "deepmerge-ts" {
   interface DeepMergeMergeFunctionURItoKind<
-    Ts extends ReadonlyArray<unknown>,
+    Ts extends Readonly<ReadonlyArray<unknown>>,
     MF extends DeepMergeMergeFunctionsURIs
   > {
     readonly MyDeepMergeDatesURI: EveryIsDate<Ts> extends true ? Ts : DeepMergeLeaf<Ts>;
   }
 }
 
-type EveryIsDate<Ts extends ReadonlyArray<unknown>> = Ts extends readonly [
-  infer Head,
-  ...infer Rest
-]
+type EveryIsDate<Ts extends Readonly<ReadonlyArray<unknown>>> = Ts extends Readonly<
+  readonly [infer Head, ...infer Rest]
+>
   ? Head extends Date
     ? EveryIsDate<Rest>
     : false

--- a/src/deepmerge.ts
+++ b/src/deepmerge.ts
@@ -36,8 +36,8 @@ export type DeepMergeMergeFunctionsDefaults = typeof defaultOptions;
  *
  * @param objects - The objects to merge.
  */
-export function deepmerge<Ts extends ReadonlyArray<unknown>>(
-  ...objects: readonly [...Ts]
+export function deepmerge<Ts extends Readonly<ReadonlyArray<unknown>>>(
+  ...objects: Readonly<readonly [...Ts]>
 ): DeepMergeHKT<Ts, DeepMergeMergeFunctionsDefaultURIs> {
   return deepmergeCustom({})(...objects) as DeepMergeHKT<
     Ts,
@@ -54,13 +54,13 @@ export function deepmergeCustom<
   PMF extends Partial<DeepMergeMergeFunctionsURIs>
 >(
   options: DeepMergeOptions
-): <Ts extends ReadonlyArray<unknown>>(
+): <Ts extends Readonly<ReadonlyArray<unknown>>>(
   ...objects: Ts
 ) => DeepMergeHKT<Ts, GetDeepMergeMergeFunctionsURIs<PMF>> {
   /**
    * The type of the customized deepmerge function.
    */
-  type CustomizedDeepmerge = <Ts extends ReadonlyArray<unknown>>(
+  type CustomizedDeepmerge = <Ts extends Readonly<ReadonlyArray<unknown>>>(
     ...objects: Ts
   ) => DeepMergeHKT<Ts, GetDeepMergeMergeFunctionsURIs<PMF>>;
 
@@ -69,7 +69,7 @@ export function deepmergeCustom<
   /**
    * The customized deepmerge function.
    */
-  function customizedDeepmerge(...objects: ReadonlyArray<unknown>) {
+  function customizedDeepmerge(...objects: Readonly<ReadonlyArray<unknown>>) {
     if (objects.length === 0) {
       return undefined;
     }
@@ -112,7 +112,7 @@ function getUtils(
  * @param values - The values.
  */
 function mergeUnknowns<
-  Ts extends ReadonlyArray<unknown>,
+  Ts extends Readonly<ReadonlyArray<unknown>>,
   U extends DeepMergeMergeFunctionUtils,
   MF extends DeepMergeMergeFunctionsURIs
 >(values: Ts, utils: U): DeepMergeHKT<Ts, MF> {
@@ -136,25 +136,29 @@ function mergeUnknowns<
   switch (type) {
     case ObjectType.RECORD:
       return utils.mergeFunctions.mergeRecords(
-        values as ReadonlyArray<Readonly<Record<PropertyKey, unknown>>>,
+        values as Readonly<
+          ReadonlyArray<Readonly<Record<PropertyKey, unknown>>>
+        >,
         utils
       ) as DeepMergeHKT<Ts, MF>;
 
     case ObjectType.ARRAY:
       return utils.mergeFunctions.mergeArrays(
-        values as ReadonlyArray<ReadonlyArray<unknown>>,
+        values as Readonly<ReadonlyArray<Readonly<ReadonlyArray<unknown>>>>,
         utils
       ) as DeepMergeHKT<Ts, MF>;
 
     case ObjectType.SET:
       return utils.mergeFunctions.mergeSets(
-        values as ReadonlyArray<Readonly<ReadonlySet<unknown>>>,
+        values as Readonly<ReadonlyArray<Readonly<ReadonlySet<unknown>>>>,
         utils
       ) as DeepMergeHKT<Ts, MF>;
 
     case ObjectType.MAP:
       return utils.mergeFunctions.mergeMaps(
-        values as ReadonlyArray<Readonly<ReadonlyMap<unknown, unknown>>>,
+        values as Readonly<
+          ReadonlyArray<Readonly<ReadonlyMap<unknown, unknown>>>
+        >,
         utils
       ) as DeepMergeHKT<Ts, MF>;
 
@@ -172,7 +176,7 @@ function mergeUnknowns<
  * @param values - The records.
  */
 function mergeRecords<
-  Ts extends ReadonlyArray<Record<PropertyKey, unknown>>,
+  Ts extends Readonly<ReadonlyArray<Record<PropertyKey, unknown>>>,
   U extends DeepMergeMergeFunctionUtils,
   MF extends DeepMergeMergeFunctionsURIs
 >(values: Ts, utils: U) {
@@ -208,7 +212,7 @@ function mergeRecords<
  * @param values - The arrays.
  */
 function mergeArrays<
-  Ts extends ReadonlyArray<ReadonlyArray<unknown>>,
+  Ts extends Readonly<ReadonlyArray<Readonly<ReadonlyArray<unknown>>>>,
   U extends DeepMergeMergeFunctionUtils,
   MF extends DeepMergeMergeFunctionsURIs
 >(values: Ts, utils: U) {
@@ -221,7 +225,7 @@ function mergeArrays<
  * @param values - The sets.
  */
 function mergeSets<
-  Ts extends ReadonlyArray<Readonly<ReadonlySet<unknown>>>,
+  Ts extends Readonly<ReadonlyArray<Readonly<ReadonlySet<unknown>>>>,
   U extends DeepMergeMergeFunctionUtils,
   MF extends DeepMergeMergeFunctionsURIs
 >(values: Ts, utils: U) {
@@ -237,7 +241,7 @@ function mergeSets<
  * @param values - The maps.
  */
 function mergeMaps<
-  Ts extends ReadonlyArray<Readonly<ReadonlyMap<unknown, unknown>>>,
+  Ts extends Readonly<ReadonlyArray<Readonly<ReadonlyMap<unknown, unknown>>>>,
   U extends DeepMergeMergeFunctionUtils,
   MF extends DeepMergeMergeFunctionsURIs
 >(values: Ts, utils: U) {
@@ -253,7 +257,7 @@ function mergeMaps<
  * @param values - The values.
  */
 function leaf<
-  Ts extends ReadonlyArray<unknown>,
+  Ts extends Readonly<ReadonlyArray<unknown>>,
   U extends DeepMergeMergeFunctionUtils,
   MF extends DeepMergeMergeFunctionsURIs
 >(values: Ts, utils: U) {

--- a/src/types/defaults.ts
+++ b/src/types/defaults.ts
@@ -38,13 +38,13 @@ type DeepMergeMapsDefaultURI = "DeepMergeMapsDefaultURI";
 /**
  * The default merge functions to use when deep merging.
  */
-export type DeepMergeMergeFunctionsDefaultURIs = {
+export type DeepMergeMergeFunctionsDefaultURIs = Readonly<{
   DeepMergeRecordsURI: DeepMergeRecordsDefaultURI;
   DeepMergeArraysURI: DeepMergeArraysDefaultURI;
   DeepMergeSetsURI: DeepMergeSetsDefaultURI;
   DeepMergeMapsURI: DeepMergeMapsDefaultURI;
   DeepMergeOthersURI: DeepMergeLeafURI;
-};
+}>;
 
 /**
  * A union of all the props that should not be included in type information for
@@ -56,9 +56,9 @@ type BlacklistedRecordProps = "__proto__";
  * Deep merge records.
  */
 export type DeepMergeRecordsDefaultHKT<
-  Ts extends ReadonlyArray<unknown>,
+  Ts extends Readonly<ReadonlyArray<unknown>>,
   MF extends DeepMergeMergeFunctionsURIs
-> = Ts extends readonly [unknown, ...unknown[]]
+> = Ts extends Readonly<readonly [unknown, ...Readonly<ReadonlyArray<unknown>>]>
   ? FlatternAlias<
       Omit<
         DeepMergeRecordsDefaultHKTInternalProps<Ts, MF>,
@@ -71,7 +71,7 @@ export type DeepMergeRecordsDefaultHKT<
  * Deep merge record props.
  */
 type DeepMergeRecordsDefaultHKTInternalProps<
-  Ts extends readonly [unknown, ...unknown[]],
+  Ts extends Readonly<readonly [unknown, ...Readonly<ReadonlyArray<unknown>>]>,
   MF extends DeepMergeMergeFunctionsURIs
 > = {
   [K in OptionalKeysOf<Ts>]?: DeepMergeHKT<
@@ -89,22 +89,28 @@ type DeepMergeRecordsDefaultHKTInternalProps<
  * Get the value of the property.
  */
 type DeepMergeRecordsDefaultHKTInternalPropValue<
-  Ts extends readonly [unknown, ...unknown[]],
+  Ts extends Readonly<readonly [unknown, ...Readonly<ReadonlyArray<unknown>>]>,
   K extends PropertyKey
 > = FilterOutNever<
-  DeepMergeRecordsDefaultHKTInternalPropValueHelper<Ts, K, []>
+  DeepMergeRecordsDefaultHKTInternalPropValueHelper<
+    Ts,
+    K,
+    Readonly<readonly []>
+  >
 >;
 
 /**
  * Tail-recursive helper type for DeepMergeRecordsDefaultHKTInternalPropValue.
  */
 type DeepMergeRecordsDefaultHKTInternalPropValueHelper<
-  Ts extends readonly [unknown, ...unknown[]],
+  Ts extends Readonly<readonly [unknown, ...Readonly<ReadonlyArray<unknown>>]>,
   K extends PropertyKey,
-  Acc extends ReadonlyArray<unknown>
-> = Ts extends readonly [infer Head, ...infer Rest]
+  Acc extends Readonly<ReadonlyArray<unknown>>
+> = Ts extends Readonly<readonly [infer Head, ...infer Rest]>
   ? Head extends Record<PropertyKey, unknown>
-    ? Rest extends readonly [unknown, ...unknown[]]
+    ? Rest extends Readonly<
+        readonly [unknown, ...Readonly<ReadonlyArray<unknown>>]
+      >
       ? DeepMergeRecordsDefaultHKTInternalPropValueHelper<
           Rest,
           K,
@@ -118,7 +124,7 @@ type DeepMergeRecordsDefaultHKTInternalPropValueHelper<
  * Deep merge 2 arrays.
  */
 export type DeepMergeArraysDefaultHKT<
-  Ts extends ReadonlyArray<unknown>,
+  Ts extends Readonly<ReadonlyArray<unknown>>,
   MF extends DeepMergeMergeFunctionsURIs
 > = DeepMergeArraysDefaultHKTHelper<Ts, MF, []>;
 
@@ -126,14 +132,14 @@ export type DeepMergeArraysDefaultHKT<
  * Tail-recursive helper type for DeepMergeArraysDefaultHKT.
  */
 type DeepMergeArraysDefaultHKTHelper<
-  Ts extends ReadonlyArray<unknown>,
+  Ts extends Readonly<ReadonlyArray<unknown>>,
   MF extends DeepMergeMergeFunctionsURIs,
-  Acc extends ReadonlyArray<unknown>
+  Acc extends Readonly<ReadonlyArray<unknown>>
 > = Ts extends readonly [infer Head, ...infer Rest]
-  ? Head extends ReadonlyArray<unknown>
+  ? Head extends Readonly<ReadonlyArray<unknown>>
     ? Rest extends readonly [
-        ReadonlyArray<unknown>,
-        ...ReadonlyArray<ReadonlyArray<unknown>>
+        Readonly<ReadonlyArray<unknown>>,
+        ...Readonly<ReadonlyArray<Readonly<ReadonlyArray<unknown>>>>
       ]
       ? DeepMergeArraysDefaultHKTHelper<Rest, MF, [...Acc, ...Head]>
       : [...Acc, ...Head]
@@ -144,7 +150,7 @@ type DeepMergeArraysDefaultHKTHelper<
  * Deep merge 2 sets.
  */
 export type DeepMergeSetsDefaultHKT<
-  Ts extends ReadonlyArray<unknown>,
+  Ts extends Readonly<ReadonlyArray<unknown>>,
   MF extends DeepMergeMergeFunctionsURIs
 > = Set<UnionSetValues<Ts>>;
 
@@ -152,7 +158,7 @@ export type DeepMergeSetsDefaultHKT<
  * Deep merge 2 maps.
  */
 export type DeepMergeMapsDefaultHKT<
-  Ts extends ReadonlyArray<unknown>,
+  Ts extends Readonly<ReadonlyArray<unknown>>,
   MF extends DeepMergeMergeFunctionsURIs
 > = Map<UnionMapKeys<Ts>, UnionMapValues<Ts>>;
 
@@ -161,7 +167,7 @@ export type DeepMergeMapsDefaultHKT<
  */
 export type GetDeepMergeMergeFunctionsURIs<
   PMF extends Partial<DeepMergeMergeFunctionsURIs>
-> = {
+> = Readonly<{
   // prettier-ignore
   DeepMergeRecordsURI:
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -196,4 +202,4 @@ export type GetDeepMergeMergeFunctionsURIs<
     PMF["DeepMergeOthersURI"] extends keyof DeepMergeMergeFunctionURItoKind<any, any>
       ? PMF["DeepMergeOthersURI"]
       : DeepMergeLeafURI;
-};
+}>;

--- a/src/types/merging.ts
+++ b/src/types/merging.ts
@@ -18,7 +18,7 @@ import type {
  */
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface DeepMergeMergeFunctionURItoKind<
-  Ts extends ReadonlyArray<unknown>,
+  Ts extends Readonly<ReadonlyArray<unknown>>,
   MF extends DeepMergeMergeFunctionsURIs
 > {
   readonly DeepMergeLeafURI: DeepMergeLeafHKT<Ts, MF>;
@@ -33,7 +33,7 @@ export interface DeepMergeMergeFunctionURItoKind<
  */
 type DeepMergeMergeFunctionKind<
   URI extends DeepMergeMergeFunctionURIs,
-  Ts extends ReadonlyArray<unknown>,
+  Ts extends Readonly<ReadonlyArray<unknown>>,
   MF extends DeepMergeMergeFunctionsURIs
 > = DeepMergeMergeFunctionURItoKind<Ts, MF>[URI];
 
@@ -41,14 +41,14 @@ type DeepMergeMergeFunctionKind<
  * A union of all valid merge function URIs.
  */
 type DeepMergeMergeFunctionURIs = keyof DeepMergeMergeFunctionURItoKind<
-  ReadonlyArray<unknown>,
+  Readonly<ReadonlyArray<unknown>>,
   DeepMergeMergeFunctionsURIs
 >;
 
 /**
  * The merge functions to use when deep merging.
  */
-export type DeepMergeMergeFunctionsURIs = {
+export type DeepMergeMergeFunctionsURIs = Readonly<{
   /**
    * The merge function to merge records with.
    */
@@ -73,18 +73,18 @@ export type DeepMergeMergeFunctionsURIs = {
    * The merge function to merge other things with.
    */
   DeepMergeOthersURI: DeepMergeMergeFunctionURIs;
-};
+}>;
 
 /**
  * Deep merge types.
  */
 export type DeepMergeHKT<
-  Ts extends ReadonlyArray<unknown>,
+  Ts extends Readonly<ReadonlyArray<unknown>>,
   MF extends DeepMergeMergeFunctionsURIs
 > = IsTuple<Ts> extends true
-  ? Ts extends readonly []
+  ? Ts extends Readonly<readonly []>
     ? undefined
-    : Ts extends readonly [infer T1]
+    : Ts extends Readonly<readonly [infer T1]>
     ? T1
     : EveryIsArray<Ts> extends true
     ? DeepMergeArraysHKT<Ts, MF>
@@ -101,7 +101,7 @@ export type DeepMergeHKT<
  * Deep merge records.
  */
 type DeepMergeRecordsHKT<
-  Ts extends ReadonlyArray<unknown>,
+  Ts extends Readonly<ReadonlyArray<unknown>>,
   MF extends DeepMergeMergeFunctionsURIs
 > = DeepMergeMergeFunctionKind<MF["DeepMergeRecordsURI"], Ts, MF>;
 
@@ -109,7 +109,7 @@ type DeepMergeRecordsHKT<
  * Deep merge arrays.
  */
 type DeepMergeArraysHKT<
-  Ts extends ReadonlyArray<unknown>,
+  Ts extends Readonly<ReadonlyArray<unknown>>,
   MF extends DeepMergeMergeFunctionsURIs
 > = DeepMergeMergeFunctionKind<MF["DeepMergeArraysURI"], Ts, MF>;
 
@@ -117,7 +117,7 @@ type DeepMergeArraysHKT<
  * Deep merge sets.
  */
 type DeepMergeSetsHKT<
-  Ts extends ReadonlyArray<unknown>,
+  Ts extends Readonly<ReadonlyArray<unknown>>,
   MF extends DeepMergeMergeFunctionsURIs
 > = DeepMergeMergeFunctionKind<MF["DeepMergeSetsURI"], Ts, MF>;
 
@@ -125,7 +125,7 @@ type DeepMergeSetsHKT<
  * Deep merge maps.
  */
 type DeepMergeMapsHKT<
-  Ts extends ReadonlyArray<unknown>,
+  Ts extends Readonly<ReadonlyArray<unknown>>,
   MF extends DeepMergeMergeFunctionsURIs
 > = DeepMergeMergeFunctionKind<MF["DeepMergeMapsURI"], Ts, MF>;
 
@@ -133,7 +133,7 @@ type DeepMergeMapsHKT<
  * Deep merge other things.
  */
 type DeepMergeOthersHKT<
-  Ts extends ReadonlyArray<unknown>,
+  Ts extends Readonly<ReadonlyArray<unknown>>,
   MF extends DeepMergeMergeFunctionsURIs
 > = DeepMergeMergeFunctionKind<MF["DeepMergeOthersURI"], Ts, MF>;
 
@@ -146,21 +146,21 @@ export type DeepMergeLeafURI = "DeepMergeLeafURI";
  * Get the leaf type from 2 types that can't be merged.
  */
 export type DeepMergeLeafHKT<
-  Ts extends ReadonlyArray<unknown>,
+  Ts extends Readonly<ReadonlyArray<unknown>>,
   MF extends DeepMergeMergeFunctionsURIs
 > = DeepMergeLeaf<Ts>;
 
 /**
  * Get the leaf type from many types that can't be merged.
  */
-export type DeepMergeLeaf<Ts extends ReadonlyArray<unknown>> =
-  Ts extends readonly []
+export type DeepMergeLeaf<Ts extends Readonly<ReadonlyArray<unknown>>> =
+  Ts extends Readonly<readonly []>
     ? never
-    : Ts extends [infer T]
+    : Ts extends Readonly<readonly [infer T]>
     ? T
-    : Ts extends [...infer Rest, infer Tail]
+    : Ts extends Readonly<readonly [...infer Rest, infer Tail]>
     ? IsNever<Tail> extends true
-      ? Rest extends ReadonlyArray<unknown>
+      ? Rest extends Readonly<ReadonlyArray<unknown>>
         ? DeepMergeLeaf<Rest>
         : never
       : Tail

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -21,7 +21,7 @@ type DeepMergeOptionsFull = Readonly<{
  */
 type DeepMergeMergeFunctions = Readonly<{
   mergeRecords: <
-    Ts extends ReadonlyArray<Readonly<Record<PropertyKey, unknown>>>,
+    Ts extends Readonly<ReadonlyArray<Readonly<Record<PropertyKey, unknown>>>>,
     U extends DeepMergeMergeFunctionUtils
   >(
     records: Ts,
@@ -29,7 +29,7 @@ type DeepMergeMergeFunctions = Readonly<{
   ) => unknown;
 
   mergeArrays: <
-    Ts extends ReadonlyArray<Readonly<ReadonlyArray<unknown>>>,
+    Ts extends Readonly<ReadonlyArray<Readonly<ReadonlyArray<unknown>>>>,
     U extends DeepMergeMergeFunctionUtils
   >(
     records: Ts,
@@ -37,7 +37,7 @@ type DeepMergeMergeFunctions = Readonly<{
   ) => unknown;
 
   mergeMaps: <
-    Ts extends ReadonlyArray<Readonly<ReadonlyMap<unknown, unknown>>>,
+    Ts extends Readonly<ReadonlyArray<Readonly<ReadonlyMap<unknown, unknown>>>>,
     U extends DeepMergeMergeFunctionUtils
   >(
     records: Ts,
@@ -45,7 +45,7 @@ type DeepMergeMergeFunctions = Readonly<{
   ) => unknown;
 
   mergeSets: <
-    Ts extends ReadonlyArray<Readonly<ReadonlySet<unknown>>>,
+    Ts extends Readonly<ReadonlyArray<Readonly<ReadonlySet<unknown>>>>,
     U extends DeepMergeMergeFunctionUtils
   >(
     records: Ts,
@@ -53,7 +53,7 @@ type DeepMergeMergeFunctions = Readonly<{
   ) => unknown;
 
   mergeOthers: <
-    Ts extends ReadonlyArray<unknown>,
+    Ts extends Readonly<ReadonlyArray<unknown>>,
     U extends DeepMergeMergeFunctionUtils
   >(
     records: Ts,
@@ -67,5 +67,7 @@ type DeepMergeMergeFunctions = Readonly<{
 export type DeepMergeMergeFunctionUtils = Readonly<{
   mergeFunctions: DeepMergeMergeFunctions;
   defaultMergeFunctions: DeepMergeMergeFunctionsDefaults;
-  deepmerge: <Ts extends ReadonlyArray<unknown>>(...values: Ts) => unknown;
+  deepmerge: <Ts extends Readonly<ReadonlyArray<unknown>>>(
+    ...values: Ts
+  ) => unknown;
 }>;

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -27,16 +27,14 @@ export type IsNever<T> = Is<T, never>;
 /**
  * Returns whether or not all the given types are never.
  */
-export type EveryIsNever<Ts extends ReadonlyArray<unknown>> = Ts extends [
-  infer Head,
-  ...infer Rest
-]
-  ? IsNever<Head> extends true
-    ? Rest extends ReadonlyArray<unknown>
-      ? EveryIsNever<Rest>
-      : true
-    : false
-  : true;
+export type EveryIsNever<Ts extends Readonly<ReadonlyArray<unknown>>> =
+  Ts extends Readonly<readonly [infer Head, ...infer Rest]>
+    ? IsNever<Head> extends true
+      ? Rest extends Readonly<ReadonlyArray<unknown>>
+        ? EveryIsNever<Rest>
+        : true
+      : false
+    : true;
 
 /**
  * Returns whether or not the given type a record.
@@ -49,39 +47,38 @@ export type IsRecord<T> = And<
 /**
  * Returns whether or not all the given types are records.
  */
-export type EveryIsRecord<Ts extends ReadonlyArray<unknown>> = Ts extends [
-  infer Head,
-  ...infer Rest
-]
-  ? IsRecord<Head> extends true
-    ? Rest extends ReadonlyArray<unknown>
-      ? EveryIsRecord<Rest>
-      : true
-    : false
-  : true;
+export type EveryIsRecord<Ts extends Readonly<ReadonlyArray<unknown>>> =
+  Ts extends Readonly<readonly [infer Head, ...infer Rest]>
+    ? IsRecord<Head> extends true
+      ? Rest extends Readonly<ReadonlyArray<unknown>>
+        ? EveryIsRecord<Rest>
+        : true
+      : false
+    : true;
 
 /**
  * Returns whether or not the given type is an array.
  */
 export type IsArray<T> = And<
   Not<IsNever<T>>,
-  T extends ReadonlyArray<unknown> ? true : false
+  T extends Readonly<ReadonlyArray<unknown>> ? true : false
 >;
 
 /**
  * Returns whether or not all the given types are arrays.
  */
-export type EveryIsArray<Ts extends ReadonlyArray<unknown>> = Ts extends [
-  infer T1
-]
-  ? IsArray<T1>
-  : Ts extends [infer Head, ...infer Rest]
-  ? IsArray<Head> extends true
-    ? Rest extends [unknown, ...ReadonlyArray<unknown>]
-      ? EveryIsArray<Rest>
+export type EveryIsArray<Ts extends Readonly<ReadonlyArray<unknown>>> =
+  Ts extends Readonly<readonly [infer T1]>
+    ? IsArray<T1>
+    : Ts extends Readonly<readonly [infer Head, ...infer Rest]>
+    ? IsArray<Head> extends true
+      ? Rest extends Readonly<
+          readonly [unknown, ...Readonly<ReadonlyArray<unknown>>]
+        >
+        ? EveryIsArray<Rest>
+        : false
       : false
-    : false
-  : false;
+    : false;
 
 /**
  * Returns whether or not the given type is an set.
@@ -98,17 +95,18 @@ export type IsSet<T> = And<
  *
  * Note: This may also return true if all are maps.
  */
-export type EveryIsSet<Ts extends ReadonlyArray<unknown>> = Ts extends [
-  infer T1
-]
-  ? IsSet<T1>
-  : Ts extends [infer Head, ...infer Rest]
-  ? IsSet<Head> extends true
-    ? Rest extends [unknown, ...ReadonlyArray<unknown>]
-      ? EveryIsSet<Rest>
+export type EveryIsSet<Ts extends Readonly<ReadonlyArray<unknown>>> =
+  Ts extends Readonly<readonly [infer T1]>
+    ? IsSet<T1>
+    : Ts extends Readonly<readonly [infer Head, ...infer Rest]>
+    ? IsSet<Head> extends true
+      ? Rest extends Readonly<
+          readonly [unknown, ...Readonly<ReadonlyArray<unknown>>]
+        >
+        ? EveryIsSet<Rest>
+        : false
       : false
-    : false
-  : false;
+    : false;
 
 /**
  * Returns whether or not the given type is an map.
@@ -121,17 +119,18 @@ export type IsMap<T> = And<
 /**
  * Returns whether or not all the given types are maps.
  */
-export type EveryIsMap<Ts extends ReadonlyArray<unknown>> = Ts extends [
-  infer T1
-]
-  ? IsMap<T1>
-  : Ts extends [infer Head, ...infer Rest]
-  ? IsMap<Head> extends true
-    ? Rest extends [unknown, ...ReadonlyArray<unknown>]
-      ? EveryIsMap<Rest>
+export type EveryIsMap<Ts extends Readonly<ReadonlyArray<unknown>>> =
+  Ts extends Readonly<readonly [infer T1]>
+    ? IsMap<T1>
+    : Ts extends Readonly<readonly [infer Head, ...infer Rest]>
+    ? IsMap<Head> extends true
+      ? Rest extends Readonly<
+          readonly [unknown, ...Readonly<ReadonlyArray<unknown>>]
+        >
+        ? EveryIsMap<Rest>
+        : false
       : false
-    : false
-  : false;
+    : false;
 
 /**
  * And operator for types.
@@ -155,18 +154,18 @@ export type Not<T extends boolean> = T extends true ? false : true;
 /**
  * Union of the sets' values' types
  */
-export type UnionSetValues<Ts extends ReadonlyArray<unknown>> =
+export type UnionSetValues<Ts extends Readonly<ReadonlyArray<unknown>>> =
   UnionSetValuesHelper<Ts, never>;
 
 /**
  * Tail-recursive helper type for UnionSetValues.
  */
 type UnionSetValuesHelper<
-  Ts extends ReadonlyArray<unknown>,
+  Ts extends Readonly<ReadonlyArray<unknown>>,
   Acc
 > = Ts extends readonly [infer Head, ...infer Rest]
-  ? Head extends Set<infer V1>
-    ? Rest extends ReadonlyArray<unknown>
+  ? Head extends Readonly<ReadonlySet<infer V1>>
+    ? Rest extends Readonly<ReadonlyArray<unknown>>
       ? UnionSetValuesHelper<Rest, Acc | V1>
       : Acc | V1
     : never
@@ -175,17 +174,17 @@ type UnionSetValuesHelper<
 /**
  * Union of the maps' values' types
  */
-export type UnionMapKeys<Ts extends ReadonlyArray<unknown>> =
+export type UnionMapKeys<Ts extends Readonly<ReadonlyArray<unknown>>> =
   UnionMapKeysHelper<Ts, never>;
 
 /**
  * Tail-recursive helper type for UnionMapKeys.
  */
 type UnionMapKeysHelper<
-  Ts extends ReadonlyArray<unknown>,
+  Ts extends Readonly<ReadonlyArray<unknown>>,
   Acc
 > = Ts extends readonly [infer Head, ...infer Rest]
-  ? Head extends Map<infer K1, unknown>
+  ? Head extends Readonly<ReadonlyMap<infer K1, unknown>>
     ? Rest extends readonly []
       ? Acc | K1
       : UnionMapKeysHelper<Rest, Acc | K1>
@@ -195,17 +194,17 @@ type UnionMapKeysHelper<
 /**
  * Union of the maps' keys' types
  */
-export type UnionMapValues<Ts extends ReadonlyArray<unknown>> =
+export type UnionMapValues<Ts extends Readonly<ReadonlyArray<unknown>>> =
   UnionMapValuesHelper<Ts, never>;
 
 /**
  * Tail-recursive helper type for UnionMapValues.
  */
 type UnionMapValuesHelper<
-  Ts extends ReadonlyArray<unknown>,
+  Ts extends Readonly<ReadonlyArray<unknown>>,
   Acc
 > = Ts extends readonly [infer Head, ...infer Rest]
-  ? Head extends Map<unknown, infer V1>
+  ? Head extends Readonly<ReadonlyMap<unknown, infer V1>>
     ? Rest extends readonly []
       ? Acc | V1
       : UnionMapValuesHelper<Rest, Acc | V1>
@@ -215,17 +214,20 @@ type UnionMapValuesHelper<
 /**
  * Get all the keys of the given records.
  */
-export type KeysOf<Ts extends ReadonlyArray<unknown>> = KeysOfHelper<Ts, never>;
+export type KeysOf<Ts extends Readonly<ReadonlyArray<unknown>>> = KeysOfHelper<
+  Ts,
+  never
+>;
 
 /**
  * Tail-recursive helper type for KeysOf.
  */
 type KeysOfHelper<
-  Ts extends ReadonlyArray<unknown>,
+  Ts extends Readonly<ReadonlyArray<unknown>>,
   Acc
 > = Ts extends readonly [infer Head, ...infer Rest]
   ? Head extends Record<PropertyKey, unknown>
-    ? Rest extends ReadonlyArray<unknown>
+    ? Rest extends Readonly<ReadonlyArray<unknown>>
       ? KeysOfHelper<Rest, Acc | keyof Head>
       : Acc | keyof Head
     : never
@@ -249,18 +251,21 @@ type RequiredKeys<T> = Exclude<
 /**
  * Get all the required keys on the types in the tuple.
  */
-export type RequiredKeysOf<Ts extends readonly [unknown, ...unknown[]]> =
-  RequiredKeysOfHelper<Ts, never>;
+export type RequiredKeysOf<
+  Ts extends Readonly<readonly [unknown, ...Readonly<ReadonlyArray<unknown>>]>
+> = RequiredKeysOfHelper<Ts, never>;
 
 /**
  * Tail-recursive helper type for RequiredKeysOf.
  */
 type RequiredKeysOfHelper<
-  Ts extends readonly [unknown, ...unknown[]],
+  Ts extends Readonly<readonly [unknown, ...Readonly<ReadonlyArray<unknown>>]>,
   Acc
-> = Ts extends readonly [infer Head, ...infer Rest]
+> = Ts extends Readonly<readonly [infer Head, ...infer Rest]>
   ? Head extends Record<PropertyKey, unknown>
-    ? Rest extends readonly [unknown, ...unknown[]]
+    ? Rest extends Readonly<
+        readonly [unknown, ...Readonly<ReadonlyArray<unknown>>]
+      >
       ? RequiredKeysOfHelper<Rest, Acc | RequiredKeys<Head>>
       : Acc | RequiredKeys<Head>
     : never
@@ -274,18 +279,21 @@ type OptionalKeys<T> = Exclude<keyof T, RequiredKeys<T>>;
 /**
  * Get all the optional keys on the types in the tuple.
  */
-export type OptionalKeysOf<Ts extends readonly [unknown, ...unknown[]]> =
-  OptionalKeysOfHelper<Ts, never>;
+export type OptionalKeysOf<
+  Ts extends Readonly<readonly [unknown, ...Readonly<ReadonlyArray<unknown>>]>
+> = OptionalKeysOfHelper<Ts, never>;
 
 /**
  * Tail-recursive helper type for OptionalKeysOf.
  */
 type OptionalKeysOfHelper<
-  Ts extends readonly [unknown, ...unknown[]],
+  Ts extends Readonly<readonly [unknown, ...Readonly<ReadonlyArray<unknown>>]>,
   Acc
 > = Ts extends readonly [infer Head, ...infer Rest]
   ? Head extends Record<PropertyKey, unknown>
-    ? Rest extends readonly [unknown, ...unknown[]]
+    ? Rest extends Readonly<
+        readonly [unknown, ...Readonly<ReadonlyArray<unknown>>]
+      >
       ? OptionalKeysOfHelper<Rest, Acc | OptionalKeys<Head>>
       : Acc | OptionalKeys<Head>
     : never
@@ -294,18 +302,18 @@ type OptionalKeysOfHelper<
 /**
  * Filter out nevers from a tuple.
  */
-export type FilterOutNever<T extends ReadonlyArray<unknown>> =
+export type FilterOutNever<T extends Readonly<ReadonlyArray<unknown>>> =
   FilterOutNeverHelper<T, []>;
 
 /**
  * Tail-recursive helper type for FilterOutNever.
  */
 type FilterOutNeverHelper<
-  T extends ReadonlyArray<unknown>,
-  Acc extends ReadonlyArray<unknown>
-> = T extends readonly []
+  T extends Readonly<ReadonlyArray<unknown>>,
+  Acc extends Readonly<ReadonlyArray<unknown>>
+> = T extends Readonly<readonly []>
   ? Acc
-  : T extends readonly [infer Head, ...infer Rest]
+  : T extends Readonly<readonly [infer Head, ...infer Rest]>
   ? IsNever<Head> extends true
     ? FilterOutNeverHelper<Rest, Acc>
     : FilterOutNeverHelper<Rest, [...Acc, Head]>
@@ -314,8 +322,11 @@ type FilterOutNeverHelper<
 /**
  * Is the type a tuple?
  */
-export type IsTuple<T extends ReadonlyArray<unknown>> = T extends readonly []
-  ? true
-  : T extends readonly [unknown, ...unknown[]]
-  ? true
-  : false;
+export type IsTuple<T extends Readonly<ReadonlyArray<unknown>>> =
+  T extends Readonly<readonly []>
+    ? true
+    : T extends Readonly<
+        readonly [unknown, ...Readonly<ReadonlyArray<unknown>>]
+      >
+    ? true
+    : false;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -90,7 +90,7 @@ export function objectHasProperty(
  * Get an iterable object that iterates over the given iterables.
  */
 export function getIterableOfIterables<T>(
-  iterables: ReadonlyArray<Readonly<Iterable<T>>>
+  iterables: Readonly<ReadonlyArray<Readonly<Iterable<T>>>>
 ): Iterable<T> {
   return {
     *[Symbol.iterator]() {

--- a/tests/deepmerge-custom.test.ts
+++ b/tests/deepmerge-custom.test.ts
@@ -53,7 +53,7 @@ test("custom merge strings", (t) => {
 declare module "../src/types" {
   // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface DeepMergeMergeFunctionURItoKind<
-    Ts extends ReadonlyArray<unknown>,
+    Ts extends Readonly<ReadonlyArray<unknown>>,
     MF extends DeepMergeMergeFunctionsURIs
   > {
     readonly CustomArrays1: string[];
@@ -98,11 +98,11 @@ test("custom merge arrays", (t) => {
 declare module "../src/types" {
   // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface DeepMergeMergeFunctionURItoKind<
-    Ts extends ReadonlyArray<unknown>,
+    Ts extends Readonly<ReadonlyArray<unknown>>,
     MF extends DeepMergeMergeFunctionsURIs
   > {
-    readonly CustomArrays2: Ts extends readonly [...infer Es]
-      ? Es extends ReadonlyArray<unknown>
+    readonly CustomArrays2: Ts extends Readonly<readonly [...infer Es]>
+      ? Es extends Readonly<ReadonlyArray<unknown>>
         ? unknown[]
         : never
       : never;
@@ -173,7 +173,7 @@ test("custom merge arrays of records", (t) => {
 declare module "../src/types" {
   // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface DeepMergeMergeFunctionURItoKind<
-    Ts extends ReadonlyArray<unknown>,
+    Ts extends Readonly<ReadonlyArray<unknown>>,
     MF extends DeepMergeMergeFunctionsURIs
   > {
     readonly CustomRecords3: Entries<DeepMergeRecordsDefaultHKT<Ts, MF>>;
@@ -223,7 +223,7 @@ test("custom merge records", (t) => {
 declare module "../src/types" {
   // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface DeepMergeMergeFunctionURItoKind<
-    Ts extends ReadonlyArray<unknown>,
+    Ts extends Readonly<ReadonlyArray<unknown>>,
     MF extends DeepMergeMergeFunctionsURIs
   > {
     readonly NoArrayMerge1: DeepMergeLeaf<Ts>;
@@ -252,21 +252,19 @@ test("custom don't merge arrays", (t) => {
 declare module "../src/types" {
   // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface DeepMergeMergeFunctionURItoKind<
-    Ts extends ReadonlyArray<unknown>,
+    Ts extends Readonly<ReadonlyArray<unknown>>,
     MF extends DeepMergeMergeFunctionsURIs
   > {
     readonly MergeDates1: EveryIsDate<Ts> extends true ? Ts : DeepMergeLeaf<Ts>;
   }
 }
 
-type EveryIsDate<Ts extends ReadonlyArray<unknown>> = Ts extends readonly [
-  infer Head,
-  ...infer Rest
-]
-  ? Head extends Date
-    ? EveryIsDate<Rest>
-    : false
-  : true;
+type EveryIsDate<Ts extends Readonly<ReadonlyArray<unknown>>> =
+  Ts extends Readonly<readonly [infer Head, ...infer Rest]>
+    ? Head extends Date
+      ? EveryIsDate<Rest>
+      : false
+    : true;
 
 test("custom merge dates", (t) => {
   const x = { foo: new Date("2020-01-01") };

--- a/tests/types/test.ts
+++ b/tests/types/test.ts
@@ -143,7 +143,7 @@ const merged1: {
   foo: Set<string | number>;
   bar: Map<string | number, string | number>;
 } =
-  // $ExpectType { foo: DeepMergeSetsDefaultHKT<[Set<number>, Set<string>], DeepMergeMergeFunctionsDefaultURIs>; bar: DeepMergeMapsDefaultHKT<[Map<string, string>, Map<number, number>], DeepMergeMergeFunctionsDefaultURIs>; }
+  // $ExpectType { foo: DeepMergeSetsDefaultHKT<[Set<number>, Set<string>], Readonly<{ DeepMergeRecordsURI: "DeepMergeRecordsDefaultURI"; DeepMergeArraysURI: "DeepMergeArraysDefaultURI"; DeepMergeSetsURI: "DeepMergeSetsDefaultURI"; DeepMergeMapsURI: "DeepMergeMapsDefaultURI"; DeepMergeOthersURI: "DeepMergeLeafURI"; }>>; bar: DeepMergeMapsDefaultHKT<[Map<string, string>, Map<number, number>], Readonly<{ DeepMergeRecordsURI: "DeepMergeRecordsDefaultURI"; DeepMergeArraysURI: "DeepMergeArraysDefaultURI"; DeepMergeSetsURI: "DeepMergeSetsDefaultURI"; DeepMergeMapsURI: "DeepMergeMapsDefaultURI"; DeepMergeOthersURI: "DeepMergeLeafURI"; }>>; }
   deepmerge(j, k);
 
 const l = new Map([[1, new Map([[1, a]])]]);
@@ -154,7 +154,7 @@ const merged2: Map<
   | Map<number, { foo: string; baz: { quux: string[] }; garply: number }>
   | Map<number, { foo: string; baz: { corge: number }; grault: number }>
 > =
-  // $ExpectType DeepMergeMapsDefaultHKT<[Map<number, Map<number, { foo: string; baz: { quux: string[]; }; garply: number; }>>, Map<number, Map<number, { foo: string; baz: { corge: number; }; grault: number; }>>], DeepMergeMergeFunctionsDefaultURIs>
+  // $ExpectType DeepMergeMapsDefaultHKT<[Map<number, Map<number, { foo: string; baz: { quux: string[]; }; garply: number; }>>, Map<number, Map<number, { foo: string; baz: { corge: number; }; grault: number; }>>], Readonly<{ DeepMergeRecordsURI: "DeepMergeRecordsDefaultURI"; DeepMergeArraysURI: "DeepMergeArraysDefaultURI"; DeepMergeSetsURI: "DeepMergeSetsDefaultURI"; DeepMergeMapsURI: "DeepMergeMapsDefaultURI"; DeepMergeOthersURI: "DeepMergeLeafURI"; }>>
   deepmerge(l, m);
 
 const first = { first: true };

--- a/types-legacy/v4_0.d.ts
+++ b/types-legacy/v4_0.d.ts
@@ -20,11 +20,11 @@ declare type DeepMergeOptionsFull = Readonly<{
  * All the merge functions that deepmerge uses.
  */
 declare type DeepMergeMergeFunctions = Readonly<{
-  mergeRecords: <Ts extends ReadonlyArray<Readonly<Record<keyof any, any>>>, U extends DeepMergeMergeFunctionUtils>(records: Ts, utils: U) => any;
-  mergeArrays: <Ts extends ReadonlyArray<Readonly<ReadonlyArray<any>>>, U extends DeepMergeMergeFunctionUtils>(records: Ts, utils: U) => any;
-  mergeMaps: <Ts extends ReadonlyArray<Readonly<ReadonlyMap<any, any>>>, U extends DeepMergeMergeFunctionUtils>(records: Ts, utils: U) => any;
-  mergeSets: <Ts extends ReadonlyArray<Readonly<ReadonlySet<any>>>, U extends DeepMergeMergeFunctionUtils>(records: Ts, utils: U) => any;
-  mergeOthers: <Ts extends ReadonlyArray<any>, U extends DeepMergeMergeFunctionUtils>(records: Ts, utils: U) => any;
+  mergeRecords: <Ts extends Readonly<ReadonlyArray<Readonly<Record<keyof any, any>>>>, U extends DeepMergeMergeFunctionUtils>(records: Ts, utils: U) => any;
+  mergeArrays: <Ts extends Readonly<ReadonlyArray<Readonly<ReadonlyArray<any>>>>, U extends DeepMergeMergeFunctionUtils>(records: Ts, utils: U) => any;
+  mergeMaps: <Ts extends Readonly<ReadonlyArray<Readonly<ReadonlyMap<any, any>>>>, U extends DeepMergeMergeFunctionUtils>(records: Ts, utils: U) => any;
+  mergeSets: <Ts extends Readonly<ReadonlyArray<Readonly<ReadonlySet<any>>>>, U extends DeepMergeMergeFunctionUtils>(records: Ts, utils: U) => any;
+  mergeOthers: <Ts extends Readonly<ReadonlyArray<any>>, U extends DeepMergeMergeFunctionUtils>(records: Ts, utils: U) => any;
 }>;
 
 /**
@@ -33,7 +33,7 @@ declare type DeepMergeMergeFunctions = Readonly<{
 declare type DeepMergeMergeFunctionUtils = Readonly<{
   mergeFunctions: DeepMergeMergeFunctions;
   defaultMergeFunctions: DeepMergeMergeFunctionsDefaults;
-  deepmerge: <Ts extends ReadonlyArray<any>>(...values: Ts) => any;
+  deepmerge: <Ts extends Readonly<ReadonlyArray<any>>>(...values: Ts) => any;
 }>;
 
 /**


### PR DESCRIPTION
BREAKING CHANGE: interface DeepMergeMergeFunctionURItoKind's signature has changed