### PR TITLE
refactor: remove Readonly wrapper around ReadonlyArrays

### DIFF
--- a/docs/deepmergeCustom.md
+++ b/docs/deepmergeCustom.md
@@ -37,7 +37,7 @@ This can be done using [Declaration Merging](https://www.typescriptlang.org/docs
 
 ```ts
 declare module "deepmerge-ts" {
-  interface DeepMergeMergeFunctionURItoKind<Ts extends Readonly<ReadonlyArray<unknown>>, MF extends DeepMergeMergeFunctionsURIs> {
+  interface DeepMergeMergeFunctionURItoKind<Ts extends ReadonlyArray<unknown>, MF extends DeepMergeMergeFunctionsURIs> {
     readonly MyCustomMergeURI: MyValue;
   }
 }
@@ -70,16 +70,14 @@ customDeepmerge(x, y, z); // => { foo: [Date, Date, Date] }
 
 declare module "deepmerge-ts" {
   interface DeepMergeMergeFunctionURItoKind<
-    Ts extends Readonly<ReadonlyArray<unknown>>,
+    Ts extends ReadonlyArray<unknown>,
     MF extends DeepMergeMergeFunctionsURIs
   > {
     readonly MyDeepMergeDatesURI: EveryIsDate<Ts> extends true ? Ts : DeepMergeLeaf<Ts>;
   }
 }
 
-type EveryIsDate<Ts extends Readonly<ReadonlyArray<unknown>>> = Ts extends Readonly<
-  readonly [infer Head, ...infer Rest]
->
+type EveryIsDate<Ts extends ReadonlyArray<unknown>> = Ts extends readonly [infer Head, ...infer Rest]
   ? Head extends Date
     ? EveryIsDate<Rest>
     : false

--- a/src/deepmerge.ts
+++ b/src/deepmerge.ts
@@ -36,8 +36,8 @@ export type DeepMergeMergeFunctionsDefaults = typeof defaultOptions;
  *
  * @param objects - The objects to merge.
  */
-export function deepmerge<Ts extends Readonly<ReadonlyArray<unknown>>>(
-  ...objects: Readonly<readonly [...Ts]>
+export function deepmerge<Ts extends ReadonlyArray<unknown>>(
+  ...objects: readonly [...Ts]
 ): DeepMergeHKT<Ts, DeepMergeMergeFunctionsDefaultURIs> {
   return deepmergeCustom({})(...objects) as DeepMergeHKT<
     Ts,
@@ -54,13 +54,13 @@ export function deepmergeCustom<
   PMF extends Partial<DeepMergeMergeFunctionsURIs>
 >(
   options: DeepMergeOptions
-): <Ts extends Readonly<ReadonlyArray<unknown>>>(
+): <Ts extends ReadonlyArray<unknown>>(
   ...objects: Ts
 ) => DeepMergeHKT<Ts, GetDeepMergeMergeFunctionsURIs<PMF>> {
   /**
    * The type of the customized deepmerge function.
    */
-  type CustomizedDeepmerge = <Ts extends Readonly<ReadonlyArray<unknown>>>(
+  type CustomizedDeepmerge = <Ts extends ReadonlyArray<unknown>>(
     ...objects: Ts
   ) => DeepMergeHKT<Ts, GetDeepMergeMergeFunctionsURIs<PMF>>;
 
@@ -69,7 +69,7 @@ export function deepmergeCustom<
   /**
    * The customized deepmerge function.
    */
-  function customizedDeepmerge(...objects: Readonly<ReadonlyArray<unknown>>) {
+  function customizedDeepmerge(...objects: ReadonlyArray<unknown>) {
     if (objects.length === 0) {
       return undefined;
     }
@@ -112,7 +112,7 @@ function getUtils(
  * @param values - The values.
  */
 function mergeUnknowns<
-  Ts extends Readonly<ReadonlyArray<unknown>>,
+  Ts extends ReadonlyArray<unknown>,
   U extends DeepMergeMergeFunctionUtils,
   MF extends DeepMergeMergeFunctionsURIs
 >(values: Ts, utils: U): DeepMergeHKT<Ts, MF> {
@@ -136,29 +136,25 @@ function mergeUnknowns<
   switch (type) {
     case ObjectType.RECORD:
       return utils.mergeFunctions.mergeRecords(
-        values as Readonly<
-          ReadonlyArray<Readonly<Record<PropertyKey, unknown>>>
-        >,
+        values as ReadonlyArray<Readonly<Record<PropertyKey, unknown>>>,
         utils
       ) as DeepMergeHKT<Ts, MF>;
 
     case ObjectType.ARRAY:
       return utils.mergeFunctions.mergeArrays(
-        values as Readonly<ReadonlyArray<Readonly<ReadonlyArray<unknown>>>>,
+        values as ReadonlyArray<ReadonlyArray<unknown>>,
         utils
       ) as DeepMergeHKT<Ts, MF>;
 
     case ObjectType.SET:
       return utils.mergeFunctions.mergeSets(
-        values as Readonly<ReadonlyArray<Readonly<ReadonlySet<unknown>>>>,
+        values as ReadonlyArray<Readonly<ReadonlySet<unknown>>>,
         utils
       ) as DeepMergeHKT<Ts, MF>;
 
     case ObjectType.MAP:
       return utils.mergeFunctions.mergeMaps(
-        values as Readonly<
-          ReadonlyArray<Readonly<ReadonlyMap<unknown, unknown>>>
-        >,
+        values as ReadonlyArray<Readonly<ReadonlyMap<unknown, unknown>>>,
         utils
       ) as DeepMergeHKT<Ts, MF>;
 
@@ -176,7 +172,7 @@ function mergeUnknowns<
  * @param values - The records.
  */
 function mergeRecords<
-  Ts extends Readonly<ReadonlyArray<Record<PropertyKey, unknown>>>,
+  Ts extends ReadonlyArray<Record<PropertyKey, unknown>>,
   U extends DeepMergeMergeFunctionUtils,
   MF extends DeepMergeMergeFunctionsURIs
 >(values: Ts, utils: U) {
@@ -212,7 +208,7 @@ function mergeRecords<
  * @param values - The arrays.
  */
 function mergeArrays<
-  Ts extends Readonly<ReadonlyArray<Readonly<ReadonlyArray<unknown>>>>,
+  Ts extends ReadonlyArray<ReadonlyArray<unknown>>,
   U extends DeepMergeMergeFunctionUtils,
   MF extends DeepMergeMergeFunctionsURIs
 >(values: Ts, utils: U) {
@@ -225,7 +221,7 @@ function mergeArrays<
  * @param values - The sets.
  */
 function mergeSets<
-  Ts extends Readonly<ReadonlyArray<Readonly<ReadonlySet<unknown>>>>,
+  Ts extends ReadonlyArray<Readonly<ReadonlySet<unknown>>>,
   U extends DeepMergeMergeFunctionUtils,
   MF extends DeepMergeMergeFunctionsURIs
 >(values: Ts, utils: U) {
@@ -241,7 +237,7 @@ function mergeSets<
  * @param values - The maps.
  */
 function mergeMaps<
-  Ts extends Readonly<ReadonlyArray<Readonly<ReadonlyMap<unknown, unknown>>>>,
+  Ts extends ReadonlyArray<Readonly<ReadonlyMap<unknown, unknown>>>,
   U extends DeepMergeMergeFunctionUtils,
   MF extends DeepMergeMergeFunctionsURIs
 >(values: Ts, utils: U) {
@@ -257,7 +253,7 @@ function mergeMaps<
  * @param values - The values.
  */
 function leaf<
-  Ts extends Readonly<ReadonlyArray<unknown>>,
+  Ts extends ReadonlyArray<unknown>,
   U extends DeepMergeMergeFunctionUtils,
   MF extends DeepMergeMergeFunctionsURIs
 >(values: Ts, utils: U) {

--- a/src/types/defaults.ts
+++ b/src/types/defaults.ts
@@ -56,9 +56,9 @@ type BlacklistedRecordProps = "__proto__";
  * Deep merge records.
  */
 export type DeepMergeRecordsDefaultHKT<
-  Ts extends Readonly<ReadonlyArray<unknown>>,
+  Ts extends ReadonlyArray<unknown>,
   MF extends DeepMergeMergeFunctionsURIs
-> = Ts extends Readonly<readonly [unknown, ...Readonly<ReadonlyArray<unknown>>]>
+> = Ts extends readonly [unknown, ...ReadonlyArray<unknown>]
   ? FlatternAlias<
       Omit<
         DeepMergeRecordsDefaultHKTInternalProps<Ts, MF>,
@@ -71,7 +71,7 @@ export type DeepMergeRecordsDefaultHKT<
  * Deep merge record props.
  */
 type DeepMergeRecordsDefaultHKTInternalProps<
-  Ts extends Readonly<readonly [unknown, ...Readonly<ReadonlyArray<unknown>>]>,
+  Ts extends readonly [unknown, ...ReadonlyArray<unknown>],
   MF extends DeepMergeMergeFunctionsURIs
 > = {
   [K in OptionalKeysOf<Ts>]?: DeepMergeHKT<
@@ -89,28 +89,22 @@ type DeepMergeRecordsDefaultHKTInternalProps<
  * Get the value of the property.
  */
 type DeepMergeRecordsDefaultHKTInternalPropValue<
-  Ts extends Readonly<readonly [unknown, ...Readonly<ReadonlyArray<unknown>>]>,
+  Ts extends readonly [unknown, ...ReadonlyArray<unknown>],
   K extends PropertyKey
 > = FilterOutNever<
-  DeepMergeRecordsDefaultHKTInternalPropValueHelper<
-    Ts,
-    K,
-    Readonly<readonly []>
-  >
+  DeepMergeRecordsDefaultHKTInternalPropValueHelper<Ts, K, readonly []>
 >;
 
 /**
  * Tail-recursive helper type for DeepMergeRecordsDefaultHKTInternalPropValue.
  */
 type DeepMergeRecordsDefaultHKTInternalPropValueHelper<
-  Ts extends Readonly<readonly [unknown, ...Readonly<ReadonlyArray<unknown>>]>,
+  Ts extends readonly [unknown, ...ReadonlyArray<unknown>],
   K extends PropertyKey,
-  Acc extends Readonly<ReadonlyArray<unknown>>
-> = Ts extends Readonly<readonly [infer Head, ...infer Rest]>
+  Acc extends ReadonlyArray<unknown>
+> = Ts extends readonly [infer Head, ...infer Rest]
   ? Head extends Record<PropertyKey, unknown>
-    ? Rest extends Readonly<
-        readonly [unknown, ...Readonly<ReadonlyArray<unknown>>]
-      >
+    ? Rest extends readonly [unknown, ...ReadonlyArray<unknown>]
       ? DeepMergeRecordsDefaultHKTInternalPropValueHelper<
           Rest,
           K,
@@ -124,7 +118,7 @@ type DeepMergeRecordsDefaultHKTInternalPropValueHelper<
  * Deep merge 2 arrays.
  */
 export type DeepMergeArraysDefaultHKT<
-  Ts extends Readonly<ReadonlyArray<unknown>>,
+  Ts extends ReadonlyArray<unknown>,
   MF extends DeepMergeMergeFunctionsURIs
 > = DeepMergeArraysDefaultHKTHelper<Ts, MF, []>;
 
@@ -132,14 +126,14 @@ export type DeepMergeArraysDefaultHKT<
  * Tail-recursive helper type for DeepMergeArraysDefaultHKT.
  */
 type DeepMergeArraysDefaultHKTHelper<
-  Ts extends Readonly<ReadonlyArray<unknown>>,
+  Ts extends ReadonlyArray<unknown>,
   MF extends DeepMergeMergeFunctionsURIs,
-  Acc extends Readonly<ReadonlyArray<unknown>>
+  Acc extends ReadonlyArray<unknown>
 > = Ts extends readonly [infer Head, ...infer Rest]
-  ? Head extends Readonly<ReadonlyArray<unknown>>
+  ? Head extends ReadonlyArray<unknown>
     ? Rest extends readonly [
-        Readonly<ReadonlyArray<unknown>>,
-        ...Readonly<ReadonlyArray<Readonly<ReadonlyArray<unknown>>>>
+        ReadonlyArray<unknown>,
+        ...ReadonlyArray<ReadonlyArray<unknown>>
       ]
       ? DeepMergeArraysDefaultHKTHelper<Rest, MF, [...Acc, ...Head]>
       : [...Acc, ...Head]
@@ -150,7 +144,7 @@ type DeepMergeArraysDefaultHKTHelper<
  * Deep merge 2 sets.
  */
 export type DeepMergeSetsDefaultHKT<
-  Ts extends Readonly<ReadonlyArray<unknown>>,
+  Ts extends ReadonlyArray<unknown>,
   MF extends DeepMergeMergeFunctionsURIs
 > = Set<UnionSetValues<Ts>>;
 
@@ -158,7 +152,7 @@ export type DeepMergeSetsDefaultHKT<
  * Deep merge 2 maps.
  */
 export type DeepMergeMapsDefaultHKT<
-  Ts extends Readonly<ReadonlyArray<unknown>>,
+  Ts extends ReadonlyArray<unknown>,
   MF extends DeepMergeMergeFunctionsURIs
 > = Map<UnionMapKeys<Ts>, UnionMapValues<Ts>>;
 

--- a/src/types/merging.ts
+++ b/src/types/merging.ts
@@ -18,7 +18,7 @@ import type {
  */
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface DeepMergeMergeFunctionURItoKind<
-  Ts extends Readonly<ReadonlyArray<unknown>>,
+  Ts extends ReadonlyArray<unknown>,
   MF extends DeepMergeMergeFunctionsURIs
 > {
   readonly DeepMergeLeafURI: DeepMergeLeafHKT<Ts, MF>;
@@ -33,7 +33,7 @@ export interface DeepMergeMergeFunctionURItoKind<
  */
 type DeepMergeMergeFunctionKind<
   URI extends DeepMergeMergeFunctionURIs,
-  Ts extends Readonly<ReadonlyArray<unknown>>,
+  Ts extends ReadonlyArray<unknown>,
   MF extends DeepMergeMergeFunctionsURIs
 > = DeepMergeMergeFunctionURItoKind<Ts, MF>[URI];
 
@@ -41,7 +41,7 @@ type DeepMergeMergeFunctionKind<
  * A union of all valid merge function URIs.
  */
 type DeepMergeMergeFunctionURIs = keyof DeepMergeMergeFunctionURItoKind<
-  Readonly<ReadonlyArray<unknown>>,
+  ReadonlyArray<unknown>,
   DeepMergeMergeFunctionsURIs
 >;
 
@@ -79,12 +79,12 @@ export type DeepMergeMergeFunctionsURIs = Readonly<{
  * Deep merge types.
  */
 export type DeepMergeHKT<
-  Ts extends Readonly<ReadonlyArray<unknown>>,
+  Ts extends ReadonlyArray<unknown>,
   MF extends DeepMergeMergeFunctionsURIs
 > = IsTuple<Ts> extends true
-  ? Ts extends Readonly<readonly []>
+  ? Ts extends readonly []
     ? undefined
-    : Ts extends Readonly<readonly [infer T1]>
+    : Ts extends readonly [infer T1]
     ? T1
     : EveryIsArray<Ts> extends true
     ? DeepMergeArraysHKT<Ts, MF>
@@ -101,7 +101,7 @@ export type DeepMergeHKT<
  * Deep merge records.
  */
 type DeepMergeRecordsHKT<
-  Ts extends Readonly<ReadonlyArray<unknown>>,
+  Ts extends ReadonlyArray<unknown>,
   MF extends DeepMergeMergeFunctionsURIs
 > = DeepMergeMergeFunctionKind<MF["DeepMergeRecordsURI"], Ts, MF>;
 
@@ -109,7 +109,7 @@ type DeepMergeRecordsHKT<
  * Deep merge arrays.
  */
 type DeepMergeArraysHKT<
-  Ts extends Readonly<ReadonlyArray<unknown>>,
+  Ts extends ReadonlyArray<unknown>,
   MF extends DeepMergeMergeFunctionsURIs
 > = DeepMergeMergeFunctionKind<MF["DeepMergeArraysURI"], Ts, MF>;
 
@@ -117,7 +117,7 @@ type DeepMergeArraysHKT<
  * Deep merge sets.
  */
 type DeepMergeSetsHKT<
-  Ts extends Readonly<ReadonlyArray<unknown>>,
+  Ts extends ReadonlyArray<unknown>,
   MF extends DeepMergeMergeFunctionsURIs
 > = DeepMergeMergeFunctionKind<MF["DeepMergeSetsURI"], Ts, MF>;
 
@@ -125,7 +125,7 @@ type DeepMergeSetsHKT<
  * Deep merge maps.
  */
 type DeepMergeMapsHKT<
-  Ts extends Readonly<ReadonlyArray<unknown>>,
+  Ts extends ReadonlyArray<unknown>,
   MF extends DeepMergeMergeFunctionsURIs
 > = DeepMergeMergeFunctionKind<MF["DeepMergeMapsURI"], Ts, MF>;
 
@@ -133,7 +133,7 @@ type DeepMergeMapsHKT<
  * Deep merge other things.
  */
 type DeepMergeOthersHKT<
-  Ts extends Readonly<ReadonlyArray<unknown>>,
+  Ts extends ReadonlyArray<unknown>,
   MF extends DeepMergeMergeFunctionsURIs
 > = DeepMergeMergeFunctionKind<MF["DeepMergeOthersURI"], Ts, MF>;
 
@@ -146,21 +146,21 @@ export type DeepMergeLeafURI = "DeepMergeLeafURI";
  * Get the leaf type from 2 types that can't be merged.
  */
 export type DeepMergeLeafHKT<
-  Ts extends Readonly<ReadonlyArray<unknown>>,
+  Ts extends ReadonlyArray<unknown>,
   MF extends DeepMergeMergeFunctionsURIs
 > = DeepMergeLeaf<Ts>;
 
 /**
  * Get the leaf type from many types that can't be merged.
  */
-export type DeepMergeLeaf<Ts extends Readonly<ReadonlyArray<unknown>>> =
-  Ts extends Readonly<readonly []>
+export type DeepMergeLeaf<Ts extends ReadonlyArray<unknown>> =
+  Ts extends readonly []
     ? never
-    : Ts extends Readonly<readonly [infer T]>
+    : Ts extends readonly [infer T]
     ? T
-    : Ts extends Readonly<readonly [...infer Rest, infer Tail]>
+    : Ts extends readonly [...infer Rest, infer Tail]
     ? IsNever<Tail> extends true
-      ? Rest extends Readonly<ReadonlyArray<unknown>>
+      ? Rest extends ReadonlyArray<unknown>
         ? DeepMergeLeaf<Rest>
         : never
       : Tail

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -21,7 +21,7 @@ type DeepMergeOptionsFull = Readonly<{
  */
 type DeepMergeMergeFunctions = Readonly<{
   mergeRecords: <
-    Ts extends Readonly<ReadonlyArray<Readonly<Record<PropertyKey, unknown>>>>,
+    Ts extends ReadonlyArray<Readonly<Record<PropertyKey, unknown>>>,
     U extends DeepMergeMergeFunctionUtils
   >(
     records: Ts,
@@ -29,7 +29,7 @@ type DeepMergeMergeFunctions = Readonly<{
   ) => unknown;
 
   mergeArrays: <
-    Ts extends Readonly<ReadonlyArray<Readonly<ReadonlyArray<unknown>>>>,
+    Ts extends ReadonlyArray<ReadonlyArray<unknown>>,
     U extends DeepMergeMergeFunctionUtils
   >(
     records: Ts,
@@ -37,7 +37,7 @@ type DeepMergeMergeFunctions = Readonly<{
   ) => unknown;
 
   mergeMaps: <
-    Ts extends Readonly<ReadonlyArray<Readonly<ReadonlyMap<unknown, unknown>>>>,
+    Ts extends ReadonlyArray<Readonly<ReadonlyMap<unknown, unknown>>>,
     U extends DeepMergeMergeFunctionUtils
   >(
     records: Ts,
@@ -45,7 +45,7 @@ type DeepMergeMergeFunctions = Readonly<{
   ) => unknown;
 
   mergeSets: <
-    Ts extends Readonly<ReadonlyArray<Readonly<ReadonlySet<unknown>>>>,
+    Ts extends ReadonlyArray<Readonly<ReadonlySet<unknown>>>,
     U extends DeepMergeMergeFunctionUtils
   >(
     records: Ts,
@@ -53,7 +53,7 @@ type DeepMergeMergeFunctions = Readonly<{
   ) => unknown;
 
   mergeOthers: <
-    Ts extends Readonly<ReadonlyArray<unknown>>,
+    Ts extends ReadonlyArray<unknown>,
     U extends DeepMergeMergeFunctionUtils
   >(
     records: Ts,
@@ -67,7 +67,5 @@ type DeepMergeMergeFunctions = Readonly<{
 export type DeepMergeMergeFunctionUtils = Readonly<{
   mergeFunctions: DeepMergeMergeFunctions;
   defaultMergeFunctions: DeepMergeMergeFunctionsDefaults;
-  deepmerge: <Ts extends Readonly<ReadonlyArray<unknown>>>(
-    ...values: Ts
-  ) => unknown;
+  deepmerge: <Ts extends ReadonlyArray<unknown>>(...values: Ts) => unknown;
 }>;

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -27,10 +27,10 @@ export type IsNever<T> = Is<T, never>;
 /**
  * Returns whether or not all the given types are never.
  */
-export type EveryIsNever<Ts extends Readonly<ReadonlyArray<unknown>>> =
-  Ts extends Readonly<readonly [infer Head, ...infer Rest]>
+export type EveryIsNever<Ts extends ReadonlyArray<unknown>> =
+  Ts extends readonly [infer Head, ...infer Rest]
     ? IsNever<Head> extends true
-      ? Rest extends Readonly<ReadonlyArray<unknown>>
+      ? Rest extends ReadonlyArray<unknown>
         ? EveryIsNever<Rest>
         : true
       : false
@@ -47,10 +47,10 @@ export type IsRecord<T> = And<
 /**
  * Returns whether or not all the given types are records.
  */
-export type EveryIsRecord<Ts extends Readonly<ReadonlyArray<unknown>>> =
-  Ts extends Readonly<readonly [infer Head, ...infer Rest]>
+export type EveryIsRecord<Ts extends ReadonlyArray<unknown>> =
+  Ts extends readonly [infer Head, ...infer Rest]
     ? IsRecord<Head> extends true
-      ? Rest extends Readonly<ReadonlyArray<unknown>>
+      ? Rest extends ReadonlyArray<unknown>
         ? EveryIsRecord<Rest>
         : true
       : false
@@ -61,20 +61,18 @@ export type EveryIsRecord<Ts extends Readonly<ReadonlyArray<unknown>>> =
  */
 export type IsArray<T> = And<
   Not<IsNever<T>>,
-  T extends Readonly<ReadonlyArray<unknown>> ? true : false
+  T extends ReadonlyArray<unknown> ? true : false
 >;
 
 /**
  * Returns whether or not all the given types are arrays.
  */
-export type EveryIsArray<Ts extends Readonly<ReadonlyArray<unknown>>> =
-  Ts extends Readonly<readonly [infer T1]>
+export type EveryIsArray<Ts extends ReadonlyArray<unknown>> =
+  Ts extends readonly [infer T1]
     ? IsArray<T1>
-    : Ts extends Readonly<readonly [infer Head, ...infer Rest]>
+    : Ts extends readonly [infer Head, ...infer Rest]
     ? IsArray<Head> extends true
-      ? Rest extends Readonly<
-          readonly [unknown, ...Readonly<ReadonlyArray<unknown>>]
-        >
+      ? Rest extends readonly [unknown, ...ReadonlyArray<unknown>]
         ? EveryIsArray<Rest>
         : false
       : false
@@ -95,18 +93,17 @@ export type IsSet<T> = And<
  *
  * Note: This may also return true if all are maps.
  */
-export type EveryIsSet<Ts extends Readonly<ReadonlyArray<unknown>>> =
-  Ts extends Readonly<readonly [infer T1]>
-    ? IsSet<T1>
-    : Ts extends Readonly<readonly [infer Head, ...infer Rest]>
-    ? IsSet<Head> extends true
-      ? Rest extends Readonly<
-          readonly [unknown, ...Readonly<ReadonlyArray<unknown>>]
-        >
-        ? EveryIsSet<Rest>
-        : false
+export type EveryIsSet<Ts extends ReadonlyArray<unknown>> = Ts extends Readonly<
+  readonly [infer T1]
+>
+  ? IsSet<T1>
+  : Ts extends readonly [infer Head, ...infer Rest]
+  ? IsSet<Head> extends true
+    ? Rest extends readonly [unknown, ...ReadonlyArray<unknown>]
+      ? EveryIsSet<Rest>
       : false
-    : false;
+    : false
+  : false;
 
 /**
  * Returns whether or not the given type is an map.
@@ -119,18 +116,17 @@ export type IsMap<T> = And<
 /**
  * Returns whether or not all the given types are maps.
  */
-export type EveryIsMap<Ts extends Readonly<ReadonlyArray<unknown>>> =
-  Ts extends Readonly<readonly [infer T1]>
-    ? IsMap<T1>
-    : Ts extends Readonly<readonly [infer Head, ...infer Rest]>
-    ? IsMap<Head> extends true
-      ? Rest extends Readonly<
-          readonly [unknown, ...Readonly<ReadonlyArray<unknown>>]
-        >
-        ? EveryIsMap<Rest>
-        : false
+export type EveryIsMap<Ts extends ReadonlyArray<unknown>> = Ts extends Readonly<
+  readonly [infer T1]
+>
+  ? IsMap<T1>
+  : Ts extends readonly [infer Head, ...infer Rest]
+  ? IsMap<Head> extends true
+    ? Rest extends readonly [unknown, ...ReadonlyArray<unknown>]
+      ? EveryIsMap<Rest>
       : false
-    : false;
+    : false
+  : false;
 
 /**
  * And operator for types.
@@ -154,18 +150,18 @@ export type Not<T extends boolean> = T extends true ? false : true;
 /**
  * Union of the sets' values' types
  */
-export type UnionSetValues<Ts extends Readonly<ReadonlyArray<unknown>>> =
+export type UnionSetValues<Ts extends ReadonlyArray<unknown>> =
   UnionSetValuesHelper<Ts, never>;
 
 /**
  * Tail-recursive helper type for UnionSetValues.
  */
 type UnionSetValuesHelper<
-  Ts extends Readonly<ReadonlyArray<unknown>>,
+  Ts extends ReadonlyArray<unknown>,
   Acc
 > = Ts extends readonly [infer Head, ...infer Rest]
   ? Head extends Readonly<ReadonlySet<infer V1>>
-    ? Rest extends Readonly<ReadonlyArray<unknown>>
+    ? Rest extends ReadonlyArray<unknown>
       ? UnionSetValuesHelper<Rest, Acc | V1>
       : Acc | V1
     : never
@@ -174,14 +170,14 @@ type UnionSetValuesHelper<
 /**
  * Union of the maps' values' types
  */
-export type UnionMapKeys<Ts extends Readonly<ReadonlyArray<unknown>>> =
+export type UnionMapKeys<Ts extends ReadonlyArray<unknown>> =
   UnionMapKeysHelper<Ts, never>;
 
 /**
  * Tail-recursive helper type for UnionMapKeys.
  */
 type UnionMapKeysHelper<
-  Ts extends Readonly<ReadonlyArray<unknown>>,
+  Ts extends ReadonlyArray<unknown>,
   Acc
 > = Ts extends readonly [infer Head, ...infer Rest]
   ? Head extends Readonly<ReadonlyMap<infer K1, unknown>>
@@ -194,14 +190,14 @@ type UnionMapKeysHelper<
 /**
  * Union of the maps' keys' types
  */
-export type UnionMapValues<Ts extends Readonly<ReadonlyArray<unknown>>> =
+export type UnionMapValues<Ts extends ReadonlyArray<unknown>> =
   UnionMapValuesHelper<Ts, never>;
 
 /**
  * Tail-recursive helper type for UnionMapValues.
  */
 type UnionMapValuesHelper<
-  Ts extends Readonly<ReadonlyArray<unknown>>,
+  Ts extends ReadonlyArray<unknown>,
   Acc
 > = Ts extends readonly [infer Head, ...infer Rest]
   ? Head extends Readonly<ReadonlyMap<unknown, infer V1>>
@@ -214,20 +210,17 @@ type UnionMapValuesHelper<
 /**
  * Get all the keys of the given records.
  */
-export type KeysOf<Ts extends Readonly<ReadonlyArray<unknown>>> = KeysOfHelper<
-  Ts,
-  never
->;
+export type KeysOf<Ts extends ReadonlyArray<unknown>> = KeysOfHelper<Ts, never>;
 
 /**
  * Tail-recursive helper type for KeysOf.
  */
 type KeysOfHelper<
-  Ts extends Readonly<ReadonlyArray<unknown>>,
+  Ts extends ReadonlyArray<unknown>,
   Acc
 > = Ts extends readonly [infer Head, ...infer Rest]
   ? Head extends Record<PropertyKey, unknown>
-    ? Rest extends Readonly<ReadonlyArray<unknown>>
+    ? Rest extends ReadonlyArray<unknown>
       ? KeysOfHelper<Rest, Acc | keyof Head>
       : Acc | keyof Head
     : never
@@ -252,20 +245,18 @@ type RequiredKeys<T> = Exclude<
  * Get all the required keys on the types in the tuple.
  */
 export type RequiredKeysOf<
-  Ts extends Readonly<readonly [unknown, ...Readonly<ReadonlyArray<unknown>>]>
+  Ts extends readonly [unknown, ...ReadonlyArray<unknown>]
 > = RequiredKeysOfHelper<Ts, never>;
 
 /**
  * Tail-recursive helper type for RequiredKeysOf.
  */
 type RequiredKeysOfHelper<
-  Ts extends Readonly<readonly [unknown, ...Readonly<ReadonlyArray<unknown>>]>,
+  Ts extends readonly [unknown, ...ReadonlyArray<unknown>],
   Acc
-> = Ts extends Readonly<readonly [infer Head, ...infer Rest]>
+> = Ts extends readonly [infer Head, ...infer Rest]
   ? Head extends Record<PropertyKey, unknown>
-    ? Rest extends Readonly<
-        readonly [unknown, ...Readonly<ReadonlyArray<unknown>>]
-      >
+    ? Rest extends readonly [unknown, ...ReadonlyArray<unknown>]
       ? RequiredKeysOfHelper<Rest, Acc | RequiredKeys<Head>>
       : Acc | RequiredKeys<Head>
     : never
@@ -280,20 +271,18 @@ type OptionalKeys<T> = Exclude<keyof T, RequiredKeys<T>>;
  * Get all the optional keys on the types in the tuple.
  */
 export type OptionalKeysOf<
-  Ts extends Readonly<readonly [unknown, ...Readonly<ReadonlyArray<unknown>>]>
+  Ts extends readonly [unknown, ...ReadonlyArray<unknown>]
 > = OptionalKeysOfHelper<Ts, never>;
 
 /**
  * Tail-recursive helper type for OptionalKeysOf.
  */
 type OptionalKeysOfHelper<
-  Ts extends Readonly<readonly [unknown, ...Readonly<ReadonlyArray<unknown>>]>,
+  Ts extends readonly [unknown, ...ReadonlyArray<unknown>],
   Acc
 > = Ts extends readonly [infer Head, ...infer Rest]
   ? Head extends Record<PropertyKey, unknown>
-    ? Rest extends Readonly<
-        readonly [unknown, ...Readonly<ReadonlyArray<unknown>>]
-      >
+    ? Rest extends readonly [unknown, ...ReadonlyArray<unknown>]
       ? OptionalKeysOfHelper<Rest, Acc | OptionalKeys<Head>>
       : Acc | OptionalKeys<Head>
     : never
@@ -302,18 +291,18 @@ type OptionalKeysOfHelper<
 /**
  * Filter out nevers from a tuple.
  */
-export type FilterOutNever<T extends Readonly<ReadonlyArray<unknown>>> =
+export type FilterOutNever<T extends ReadonlyArray<unknown>> =
   FilterOutNeverHelper<T, []>;
 
 /**
  * Tail-recursive helper type for FilterOutNever.
  */
 type FilterOutNeverHelper<
-  T extends Readonly<ReadonlyArray<unknown>>,
-  Acc extends Readonly<ReadonlyArray<unknown>>
-> = T extends Readonly<readonly []>
+  T extends ReadonlyArray<unknown>,
+  Acc extends ReadonlyArray<unknown>
+> = T extends readonly []
   ? Acc
-  : T extends Readonly<readonly [infer Head, ...infer Rest]>
+  : T extends readonly [infer Head, ...infer Rest]
   ? IsNever<Head> extends true
     ? FilterOutNeverHelper<Rest, Acc>
     : FilterOutNeverHelper<Rest, [...Acc, Head]>
@@ -322,11 +311,8 @@ type FilterOutNeverHelper<
 /**
  * Is the type a tuple?
  */
-export type IsTuple<T extends Readonly<ReadonlyArray<unknown>>> =
-  T extends Readonly<readonly []>
-    ? true
-    : T extends Readonly<
-        readonly [unknown, ...Readonly<ReadonlyArray<unknown>>]
-      >
-    ? true
-    : false;
+export type IsTuple<T extends ReadonlyArray<unknown>> = T extends readonly []
+  ? true
+  : T extends readonly [unknown, ...ReadonlyArray<unknown>]
+  ? true
+  : false;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -50,9 +50,7 @@ export function getObjectType(object: unknown): ObjectType {
  * @param objects - An array of objects to get the keys of.
  * @returns A set containing all the keys of all the given objects.
  */
-export function getKeys(
-  objects: Readonly<ReadonlyArray<object>>
-): Set<PropertyKey> {
+export function getKeys(objects: ReadonlyArray<object>): Set<PropertyKey> {
   const keys = new Set<PropertyKey>();
 
   /* eslint-disable functional/no-loop-statement -- using a loop here is more efficient. */
@@ -90,7 +88,7 @@ export function objectHasProperty(
  * Get an iterable object that iterates over the given iterables.
  */
 export function getIterableOfIterables<T>(
-  iterables: Readonly<ReadonlyArray<Readonly<Iterable<T>>>>
+  iterables: ReadonlyArray<Readonly<Iterable<T>>>
 ): Iterable<T> {
   return {
     *[Symbol.iterator]() {

--- a/tests/deepmerge-custom.test.ts
+++ b/tests/deepmerge-custom.test.ts
@@ -68,7 +68,7 @@ test("custom merge strings", (t) => {
 declare module "../src/types" {
   // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface DeepMergeMergeFunctionURItoKind<
-    Ts extends Readonly<ReadonlyArray<unknown>>,
+    Ts extends ReadonlyArray<unknown>,
     MF extends DeepMergeMergeFunctionsURIs
   > {
     readonly CustomArrays1: string[];
@@ -113,11 +113,11 @@ test("custom merge arrays", (t) => {
 declare module "../src/types" {
   // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface DeepMergeMergeFunctionURItoKind<
-    Ts extends Readonly<ReadonlyArray<unknown>>,
+    Ts extends ReadonlyArray<unknown>,
     MF extends DeepMergeMergeFunctionsURIs
   > {
     readonly CustomArrays2: Ts extends Readonly<readonly [...infer Es]>
-      ? Es extends Readonly<ReadonlyArray<unknown>>
+      ? Es extends ReadonlyArray<unknown>
         ? unknown[]
         : never
       : never;
@@ -188,7 +188,7 @@ test("custom merge arrays of records", (t) => {
 declare module "../src/types" {
   // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface DeepMergeMergeFunctionURItoKind<
-    Ts extends Readonly<ReadonlyArray<unknown>>,
+    Ts extends ReadonlyArray<unknown>,
     MF extends DeepMergeMergeFunctionsURIs
   > {
     readonly CustomRecords3: Entries<DeepMergeRecordsDefaultHKT<Ts, MF>>;
@@ -238,7 +238,7 @@ test("custom merge records", (t) => {
 declare module "../src/types" {
   // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface DeepMergeMergeFunctionURItoKind<
-    Ts extends Readonly<ReadonlyArray<unknown>>,
+    Ts extends ReadonlyArray<unknown>,
     MF extends DeepMergeMergeFunctionsURIs
   > {
     readonly NoArrayMerge1: DeepMergeLeaf<Ts>;
@@ -267,19 +267,20 @@ test("custom don't merge arrays", (t) => {
 declare module "../src/types" {
   // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface DeepMergeMergeFunctionURItoKind<
-    Ts extends Readonly<ReadonlyArray<unknown>>,
+    Ts extends ReadonlyArray<unknown>,
     MF extends DeepMergeMergeFunctionsURIs
   > {
     readonly MergeDates1: EveryIsDate<Ts> extends true ? Ts : DeepMergeLeaf<Ts>;
   }
 }
 
-type EveryIsDate<Ts extends Readonly<ReadonlyArray<unknown>>> =
-  Ts extends Readonly<readonly [infer Head, ...infer Rest]>
-    ? Head extends Date
-      ? EveryIsDate<Rest>
-      : false
-    : true;
+type EveryIsDate<Ts extends ReadonlyArray<unknown>> = Ts extends Readonly<
+  readonly [infer Head, ...infer Rest]
+>
+  ? Head extends Date
+    ? EveryIsDate<Rest>
+    : false
+  : true;
 
 test("custom merge dates", (t) => {
   const x = { foo: new Date("2020-01-01") };


### PR DESCRIPTION
TypeScript treats `Readonly<ReadonlyArray<T>>` the same as `ReadonlyArray<T>`.