### PR TITLE
fix: improve meta data typings

### DIFF
--- a/docs/deepmergeCustom.md
+++ b/docs/deepmergeCustom.md
@@ -155,6 +155,9 @@ const customizedDeepmerge = deepmergeCustom<
     if (previousMeta === undefined) {
       return { keyPath: [] };
     }
+    if (metaMeta.key === undefined) {
+      return previousMeta;
+    }
     return {
       ...metaMeta,
       keyPath: [...previousMeta.keyPath, metaMeta.key],

--- a/src/deepmerge.ts
+++ b/src/deepmerge.ts
@@ -87,9 +87,7 @@ export function deepmergeCustom<
 export function deepmergeCustom<
   PMF extends Partial<DeepMergeMergeFunctionsURIs>,
   MetaData,
-  MetaMetaData extends Readonly<
-    Record<PropertyKey, unknown>
-  > = DeepMergeBuiltInMetaData
+  MetaMetaData extends DeepMergeBuiltInMetaData = DeepMergeBuiltInMetaData
 >(
   options: DeepMergeOptions<MetaData, MetaMetaData>,
   rootMetaData?: MetaData
@@ -100,7 +98,7 @@ export function deepmergeCustom<
 export function deepmergeCustom<
   PMF extends Partial<DeepMergeMergeFunctionsURIs>,
   MetaData,
-  MetaMetaData extends Readonly<Record<PropertyKey, unknown>>
+  MetaMetaData extends DeepMergeBuiltInMetaData
 >(
   options: DeepMergeOptions<MetaData, MetaMetaData>,
   rootMetaData?: MetaData
@@ -140,7 +138,7 @@ export function deepmergeCustom<
  *
  * @param options - The options the user specified
  */
-function getUtils<M, MM extends Readonly<Record<PropertyKey, unknown>>>(
+function getUtils<M, MM extends DeepMergeBuiltInMetaData>(
   options: DeepMergeOptions<M, MM>,
   customizedDeepmerge: DeepMergeMergeFunctionUtils<M, MM>["deepmerge"]
 ): DeepMergeMergeFunctionUtils<M, MM> {
@@ -177,7 +175,7 @@ function mergeUnknowns<
   U extends DeepMergeMergeFunctionUtils<M, MM>,
   MF extends DeepMergeMergeFunctionsURIs,
   M,
-  MM extends Readonly<Record<PropertyKey, unknown>>
+  MM extends DeepMergeBuiltInMetaData
 >(values: Ts, utils: U, meta: M | undefined): DeepMergeHKT<Ts, MF, M> {
   if (values.length === 0) {
     return undefined as DeepMergeHKT<Ts, MF, M>;

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -7,21 +7,18 @@ import type { DeepMergeBuiltInMetaData } from "./merging";
  */
 export type DeepMergeOptions<
   M,
-  MM extends Record<PropertyKey, unknown> = DeepMergeBuiltInMetaData
-> = Partial<DeepMergeOptionsFull<M, MM & Partial<DeepMergeBuiltInMetaData>>>;
+  MM extends Readonly<Record<PropertyKey, unknown>> = DeepMergeBuiltInMetaData
+> = Partial<DeepMergeOptionsFull<M, MM & DeepMergeBuiltInMetaData>>;
 
-type MetaDataUpdater<M, MM extends Record<PropertyKey, unknown>> = (
+type MetaDataUpdater<M, MM extends DeepMergeBuiltInMetaData> = (
   previousMeta: M | undefined,
-  metaMeta: MM
+  metaMeta: Readonly<Partial<MM>>
 ) => M;
 
 /**
  * All the options the user can pass to customize deepmerge.
  */
-type DeepMergeOptionsFull<
-  M,
-  MM extends Record<PropertyKey, unknown>
-> = Readonly<{
+type DeepMergeOptionsFull<M, MM extends DeepMergeBuiltInMetaData> = Readonly<{
   mergeRecords: DeepMergeMergeFunctions<M, MM>["mergeRecords"] | false;
   mergeArrays: DeepMergeMergeFunctions<M, MM>["mergeArrays"] | false;
   mergeMaps: DeepMergeMergeFunctions<M, MM>["mergeMaps"] | false;
@@ -35,7 +32,7 @@ type DeepMergeOptionsFull<
  */
 type DeepMergeMergeFunctions<
   M,
-  MM extends Record<PropertyKey, unknown>
+  MM extends DeepMergeBuiltInMetaData
 > = Readonly<{
   mergeRecords: <
     Ts extends ReadonlyArray<Readonly<Record<PropertyKey, unknown>>>,
@@ -88,7 +85,7 @@ type DeepMergeMergeFunctions<
  */
 export type DeepMergeMergeFunctionUtils<
   M,
-  MM extends Record<PropertyKey, unknown>
+  MM extends DeepMergeBuiltInMetaData
 > = Readonly<{
   mergeFunctions: DeepMergeMergeFunctions<M, MM>;
   defaultMergeFunctions: DeepMergeMergeFunctionsDefaults;

--- a/tests/deepmerge-custom.test.ts
+++ b/tests/deepmerge-custom.test.ts
@@ -384,6 +384,9 @@ test("key path based merging", (t) => {
     ReadonlyArray<PropertyKey>
   >({
     metaDataUpdater: (previousMeta = [], metaMeta) => {
+      if (metaMeta.key === undefined) {
+        return previousMeta;
+      }
       return [...previousMeta, metaMeta.key];
     },
     mergeOthers: (values, utils, meta) => {
@@ -466,7 +469,7 @@ test("key path based array merging", (t) => {
   ) => {
     const mergeSettings: DeepMergeOptions<
       ReadonlyArray<unknown>,
-      Readonly<Partial<{ id: unknown }>>
+      Readonly<{ id: unknown }>
     > = {
       metaDataUpdater: (previousMeta = [], metaMeta) => {
         return [...previousMeta, metaMeta.key ?? metaMeta.id];


### PR DESCRIPTION
BREAKING CHANGE: MetaMetaData now must extends DeepMergeBuiltInMetaData