### PR TITLE
fix: broken type info path

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
       "require": "./dist/node/types/current/index.d.cts"
     },
     "import": "./dist/node/index.mjs",
-    "require": "./dist/node/index.cjs"
+    "require": "./dist/node/index.cjs",
+    "default": "./dist/node/index.cjs"
   },
   "main": "dist/node/index.cjs",
   "module": "dist/node/index.mjs",
@@ -57,7 +58,7 @@
     },
     ">=4.7": {
       "*": [
-        "dist/node/types/current/index.d.ts"
+        "dist/node/types/current/index.d.mts"
       ]
     }
   },

--- a/package.json
+++ b/package.json
@@ -39,8 +39,7 @@
       "require": "./dist/node/types/current/index.d.cts"
     },
     "import": "./dist/node/index.mjs",
-    "require": "./dist/node/index.cjs",
-    "default": "./dist/node/index.cjs"
+    "require": "./dist/node/index.cjs"
   },
   "main": "dist/node/index.cjs",
   "module": "dist/node/index.mjs",


### PR DESCRIPTION
It seems you forgot to change this when updating to 4.2,
because `"dist/node/types/current/index.d.ts"` changed to `"dist/node/types/current/index.d.mts"` or `"dist/node/types/current/index.d.cts"`

fix: https://github.com/RebeccaStevens/deepmerge-ts/issues/145