### PR TITLE
feat: allow restricting what types can be passed in as parameters

### DIFF
--- a/docs/deepmergeCustom.md
+++ b/docs/deepmergeCustom.md
@@ -93,6 +93,38 @@ const customizedDeepmerge = deepmergeCustom({
 });
 ```
 
+## Restricting the Parameter Types
+
+By default, anything can be passed into a deepmerge function.
+If your custom version relies on certain input types, you can restrict the parameters that can be passed.
+This is done with the first generic that can be passed into `deepmergeCustom`.
+
+For example:
+
+```ts
+import { deepmergeCustom } from "deepmerge-ts";
+
+type Foo = {
+  foo: {
+    bar: string;
+    baz?: number;
+  };
+};
+
+const customDeepmerge = deepmergeCustom<
+  Foo // <-- Only parameters of type Foo to be passed into the function.
+>({});
+
+const x = { foo: { bar: "bar-1", baz: 3 } };
+const y = { foo: { bar: "bar-2" } };
+
+customDeepmerge(x, y); // => { foo: { bar: "bar-2", baz: 3 } }
+
+const z = { bar: "bar" };
+
+customDeepmerge(x, z); // Argument of type '{ bar: string; }' is not assignable to parameter of type 'Foo'.
+```
+
 ## Customizing the Return Type
 
 If you want to customize the deepmerge function, you probably also want the return type of the result to be correct too.\
@@ -108,9 +140,12 @@ Here's a simple example that creates a custom deepmerge function that does not m
 import type { DeepMergeLeafURI } from "deepmerge-ts";
 import { deepmergeCustom } from "deepmerge-ts";
 
-const customDeepmerge = deepmergeCustom<{
-  DeepMergeArraysURI: DeepMergeLeafURI; // <-- Needed for correct output type.
-}>({
+const customDeepmerge = deepmergeCustom<
+  unknown,                                // <-- Types that can be passed into the function.
+  {
+    DeepMergeArraysURI: DeepMergeLeafURI; // <-- Needed for correct output type.
+  }
+>({
   mergeArrays: false,
 });
 
@@ -140,9 +175,12 @@ Here's an example of creating a custom deepmerge function that amalgamates dates
 import type { DeepMergeLeaf, DeepMergeMergeFunctionURItoKind, DeepMergeMergeFunctionsURIs } from "deepmerge-ts";
 import { deepmergeCustom } from "deepmerge-ts";
 
-const customizedDeepmerge = deepmergeCustom<{
-  DeepMergeOthersURI: "MyDeepMergeDatesURI"; // <-- Needed for correct output type.
-}>({
+const customizedDeepmerge = deepmergeCustom<
+  unknown,                                      // <-- Types that can be passed into the function.
+  {
+    DeepMergeOthersURI: "MyDeepMergeDatesURI";  // <-- Needed for correct output type.
+  }
+>({
   mergeOthers: (values, utils, meta) => {
     // If every value is a date, the return the amalgamated array.
     if (values.every((value) => value instanceof Date)) {
@@ -232,6 +270,8 @@ import type { DeepMergeLeaf, DeepMergeMergeFunctionURItoKind, DeepMergeMergeFunc
 import { deepmergeCustom } from "deepmerge-ts";
 
 const customizedDeepmerge = deepmergeCustom<
+  // Allow any value to be passed into the function.
+  unknown,
   // Change the return type of `mergeOthers`.
   {
     DeepMergeOthersURI: "KeyPathBasedMerge";

--- a/src/deepmerge-into.ts
+++ b/src/deepmerge-into.ts
@@ -66,12 +66,12 @@ export function deepmergeInto<
  *
  * @param options - The options on how to customize the merge function.
  */
-export function deepmergeIntoCustom(
+export function deepmergeIntoCustom<BaseTs = unknown>(
   options: DeepMergeIntoOptions<
     DeepMergeBuiltInMetaData,
     DeepMergeBuiltInMetaData
   >
-): <Target extends object, Ts extends ReadonlyArray<unknown>>(
+): <Target extends object, Ts extends ReadonlyArray<BaseTs>>(
   target: Target,
   ...objects: Ts
 ) => void;
@@ -83,23 +83,25 @@ export function deepmergeIntoCustom(
  * @param rootMetaData - The meta data passed to the root items' being merged.
  */
 export function deepmergeIntoCustom<
-  MetaData,
+  BaseTs = unknown,
+  MetaData = DeepMergeBuiltInMetaData,
   MetaMetaData extends DeepMergeBuiltInMetaData = DeepMergeBuiltInMetaData
 >(
   options: DeepMergeIntoOptions<MetaData, MetaMetaData>,
   rootMetaData?: MetaData
-): <Target extends object, Ts extends ReadonlyArray<unknown>>(
+): <Target extends object, Ts extends ReadonlyArray<BaseTs>>(
   target: Target,
   ...objects: Ts
 ) => void;
 
 export function deepmergeIntoCustom<
+  BaseTs,
   MetaData,
   MetaMetaData extends DeepMergeBuiltInMetaData
 >(
   options: DeepMergeIntoOptions<MetaData, MetaMetaData>,
   rootMetaData?: MetaData
-): <Target extends object, Ts extends ReadonlyArray<unknown>>(
+): <Target extends object, Ts extends ReadonlyArray<BaseTs>>(
   target: Target,
   ...objects: Ts
 ) => void {

--- a/src/deepmerge.ts
+++ b/src/deepmerge.ts
@@ -38,10 +38,11 @@ export function deepmerge<Ts extends Readonly<ReadonlyArray<unknown>>>(
  * @param options - The options on how to customize the merge function.
  */
 export function deepmergeCustom<
-  PMF extends Partial<DeepMergeMergeFunctionsURIs>
+  BaseTs = unknown,
+  PMF extends Partial<DeepMergeMergeFunctionsURIs> = {}
 >(
   options: DeepMergeOptions<DeepMergeBuiltInMetaData, DeepMergeBuiltInMetaData>
-): <Ts extends ReadonlyArray<unknown>>(
+): <Ts extends ReadonlyArray<BaseTs>>(
   ...objects: Ts
 ) => DeepMergeHKT<
   Ts,
@@ -56,24 +57,26 @@ export function deepmergeCustom<
  * @param rootMetaData - The meta data passed to the root items' being merged.
  */
 export function deepmergeCustom<
-  PMF extends Partial<DeepMergeMergeFunctionsURIs>,
-  MetaData,
+  BaseTs = unknown,
+  PMF extends Partial<DeepMergeMergeFunctionsURIs> = {},
+  MetaData = DeepMergeBuiltInMetaData,
   MetaMetaData extends DeepMergeBuiltInMetaData = DeepMergeBuiltInMetaData
 >(
   options: DeepMergeOptions<MetaData, MetaMetaData>,
   rootMetaData?: MetaData
-): <Ts extends ReadonlyArray<unknown>>(
+): <Ts extends ReadonlyArray<BaseTs>>(
   ...objects: Ts
 ) => DeepMergeHKT<Ts, GetDeepMergeMergeFunctionsURIs<PMF>, MetaData>;
 
 export function deepmergeCustom<
+  BaseTs,
   PMF extends Partial<DeepMergeMergeFunctionsURIs>,
   MetaData,
   MetaMetaData extends DeepMergeBuiltInMetaData
 >(
   options: DeepMergeOptions<MetaData, MetaMetaData>,
   rootMetaData?: MetaData
-): <Ts extends ReadonlyArray<unknown>>(
+): <Ts extends ReadonlyArray<BaseTs>>(
   ...objects: Ts
 ) => DeepMergeHKT<Ts, GetDeepMergeMergeFunctionsURIs<PMF>, MetaData> {
   /**

--- a/tests/deepmerge-custom.test.ts
+++ b/tests/deepmerge-custom.test.ts
@@ -74,9 +74,12 @@ test("custom merge arrays", (t) => {
     foo: { bar: { baz: { qux: ["1a", "2b", "3c"] } } },
   };
 
-  const customizedDeepmerge = deepmergeCustom<{
-    DeepMergeArraysURI: "CustomArrays1";
-  }>({
+  const customizedDeepmerge = deepmergeCustom<
+    unknown,
+    {
+      DeepMergeArraysURI: "CustomArrays1";
+    }
+  >({
     mergeArrays: (arrays) => {
       const maxLength = Math.max(...arrays.map((array) => array.length));
 
@@ -140,10 +143,13 @@ test("custom merge arrays of records", (t) => {
     ],
   };
 
-  const customizedDeepmerge = deepmergeCustom<{
-    DeepMergeArraysURI: "CustomArrays2";
-    DeepMergeOthersURI: "CustomOthers2";
-  }>({
+  const customizedDeepmerge = deepmergeCustom<
+    unknown,
+    {
+      DeepMergeArraysURI: "CustomArrays2";
+      DeepMergeOthersURI: "CustomOthers2";
+    }
+  >({
     mergeArrays: (arrays, utils) => {
       const maxLength = Math.max(...arrays.map((array) => array.length));
       const result: unknown[] = [];
@@ -214,9 +220,12 @@ test("custom merge records", (t) => {
     ],
   ];
 
-  const customizedDeepmerge = deepmergeCustom<{
-    DeepMergeRecordsURI: "CustomRecords3";
-  }>({
+  const customizedDeepmerge = deepmergeCustom<
+    unknown,
+    {
+      DeepMergeRecordsURI: "CustomRecords3";
+    }
+  >({
     mergeRecords: (records, utils, meta) =>
       Object.entries(
         utils.defaultMergeFunctions.mergeRecords(records, utils, meta)
@@ -246,9 +255,12 @@ test("custom don't merge arrays", (t) => {
 
   const expected = { foo: [7, 8] } as const;
 
-  const customizedDeepmerge = deepmergeCustom<{
-    DeepMergeArraysURI: DeepMergeLeafURI;
-  }>({
+  const customizedDeepmerge = deepmergeCustom<
+    unknown,
+    {
+      DeepMergeArraysURI: DeepMergeLeafURI;
+    }
+  >({
     mergeArrays: false,
   });
 
@@ -282,9 +294,12 @@ test("custom merge dates", (t) => {
 
   const expected = { foo: [x.foo, y.foo, z.foo] } as const;
 
-  const customizedDeepmerge = deepmergeCustom<{
-    DeepMergeOthersURI: "MergeDates1";
-  }>({
+  const customizedDeepmerge = deepmergeCustom<
+    unknown,
+    {
+      DeepMergeOthersURI: "MergeDates1";
+    }
+  >({
     mergeOthers: (values, utils) => {
       if (values.every((value) => value instanceof Date)) {
         return values;
@@ -364,6 +379,7 @@ test("key path based merging", (t) => {
   };
 
   const customizedDeepmerge = deepmergeCustom<
+    unknown,
     {
       DeepMergeOthersURI: "KeyPathBasedMerge";
     },
@@ -711,9 +727,12 @@ test("merging class object as record", (t) => {
     foo: false,
   };
 
-  const customizedDeepmerge = deepmergeCustom<{
-    DeepMergeOthersURI: "CustomOthers3";
-  }>({
+  const customizedDeepmerge = deepmergeCustom<
+    unknown,
+    {
+      DeepMergeOthersURI: "CustomOthers3";
+    }
+  >({
     mergeOthers: (values, utils, meta) => {
       let m_allRecords = true;
       const records = values.map((v) => {

--- a/tests/deepmerge-into-custom.test.ts
+++ b/tests/deepmerge-into-custom.test.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/consistent-type-definitions, @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-unused-vars */
 
 import test from "ava";
 import _ from "lodash";
@@ -280,7 +280,10 @@ test("key path based merging", (t) => {
     bar: { baz: "special merge", qux: 9 },
   };
 
-  const customizedDeepmerge = deepmergeIntoCustom<ReadonlyArray<PropertyKey>>({
+  const customizedDeepmerge = deepmergeIntoCustom<
+    unknown,
+    ReadonlyArray<PropertyKey>
+  >({
     metaDataUpdater: (previousMeta, metaMeta) => {
       if (metaMeta.key === undefined) {
         return previousMeta ?? [];

--- a/types-legacy/v4_6.d.ts
+++ b/types-legacy/v4_6.d.ts
@@ -2,7 +2,7 @@
  * Flatten a complex type such as a union or intersection of objects into a
  * single object.
  */
-declare type FlatternAlias<T> = {
+declare type FlatternAlias<T> = Is<T, unknown> extends true ? T : {
     [P in keyof T]: T[P];
 } & {};
 /**
@@ -269,10 +269,13 @@ declare type DeepMergeRecordsDefaultHKTInternalPropValue<Ts extends readonly [un
 /**
  * Tail-recursive helper type for DeepMergeRecordsDefaultHKTInternalPropValue.
  */
-declare type DeepMergeRecordsDefaultHKTInternalPropValueHelper<Ts extends readonly [unknown, ...ReadonlyArray<unknown>], K extends PropertyKey, M, Acc extends ReadonlyArray<unknown>> = Ts extends readonly [infer Head, ...infer Rest] ? Head extends Readonly<Record<PropertyKey, unknown>> ? Rest extends readonly [unknown, ...ReadonlyArray<unknown>] ? DeepMergeRecordsDefaultHKTInternalPropValueHelper<Rest, K, M, [
+declare type DeepMergeRecordsDefaultHKTInternalPropValueHelper<Ts extends readonly [unknown, ...ReadonlyArray<unknown>], K extends PropertyKey, M, Acc extends ReadonlyArray<unknown>> = Ts extends readonly [
+    infer Head extends Readonly<Record<PropertyKey, unknown>>,
+    ...infer Rest
+] ? Rest extends readonly [unknown, ...ReadonlyArray<unknown>] ? DeepMergeRecordsDefaultHKTInternalPropValueHelper<Rest, K, M, [
     ...Acc,
     ValueOfKey<Head, K>
-]> : [...Acc, ValueOfKey<Head, K>] : never : never;
+]> : [...Acc, ValueOfKey<Head, K>] : never;
 /**
  * Deep merge 2 arrays.
  */
@@ -280,10 +283,13 @@ declare type DeepMergeArraysDefaultHKT<Ts extends ReadonlyArray<unknown>, MF ext
 /**
  * Tail-recursive helper type for DeepMergeArraysDefaultHKT.
  */
-declare type DeepMergeArraysDefaultHKTHelper<Ts extends ReadonlyArray<unknown>, MF extends DeepMergeMergeFunctionsURIs, M, Acc extends ReadonlyArray<unknown>> = Ts extends readonly [infer Head, ...infer Rest] ? Head extends ReadonlyArray<unknown> ? Rest extends readonly [
+declare type DeepMergeArraysDefaultHKTHelper<Ts extends ReadonlyArray<unknown>, MF extends DeepMergeMergeFunctionsURIs, M, Acc extends ReadonlyArray<unknown>> = Ts extends readonly [
+    infer Head extends ReadonlyArray<unknown>,
+    ...infer Rest
+] ? Rest extends readonly [
     ReadonlyArray<unknown>,
     ...ReadonlyArray<ReadonlyArray<unknown>>
-] ? DeepMergeArraysDefaultHKTHelper<Rest, MF, M, [...Acc, ...Head]> : [...Acc, ...Head] : never : never;
+] ? DeepMergeArraysDefaultHKTHelper<Rest, MF, M, [...Acc, ...Head]> : [...Acc, ...Head] : never;
 /**
  * Deep merge 2 sets.
  */
@@ -304,14 +310,100 @@ declare type GetDeepMergeMergeFunctionsURIs<PMF extends Partial<DeepMergeMergeFu
 }>;
 
 /**
+ * The default merge functions.
+ */
+declare type MergeFunctions$1 = {
+    mergeRecords: typeof mergeRecords$1;
+    mergeArrays: typeof mergeArrays$1;
+    mergeSets: typeof mergeSets$1;
+    mergeMaps: typeof mergeMaps$1;
+    mergeOthers: typeof mergeOthers$1;
+};
+/**
+ * The default strategy to merge records into a target record.
+ *
+ * @param m_target - The result will be mutated into this record
+ * @param values - The records (including the target's value if there is one).
+ */
+declare function mergeRecords$1<Ts extends ReadonlyArray<Record<PropertyKey, unknown>>, U extends DeepMergeMergeIntoFunctionUtils<M, MM>, M, MM extends DeepMergeBuiltInMetaData = DeepMergeBuiltInMetaData>(m_target: Reference<Record<PropertyKey, unknown>>, values: Ts, utils: U, meta: M | undefined): void;
+/**
+ * The default strategy to merge arrays into a target array.
+ *
+ * @param m_target - The result will be mutated into this array
+ * @param values - The arrays (including the target's value if there is one).
+ */
+declare function mergeArrays$1<Ts extends ReadonlyArray<ReadonlyArray<unknown>>>(m_target: Reference<unknown[]>, values: Ts): void;
+/**
+ * The default strategy to merge sets into a target set.
+ *
+ * @param m_target - The result will be mutated into this set
+ * @param values - The sets (including the target's value if there is one).
+ */
+declare function mergeSets$1<Ts extends ReadonlyArray<Readonly<ReadonlySet<unknown>>>>(m_target: Reference<Set<unknown>>, values: Ts): void;
+/**
+ * The default strategy to merge maps into a target map.
+ *
+ * @param m_target - The result will be mutated into this map
+ * @param values - The maps (including the target's value if there is one).
+ */
+declare function mergeMaps$1<Ts extends ReadonlyArray<Readonly<ReadonlyMap<unknown, unknown>>>>(m_target: Reference<Map<unknown, unknown>>, values: Ts): void;
+/**
+ * Set the target to the last value.
+ */
+declare function mergeOthers$1<Ts extends ReadonlyArray<unknown>>(m_target: Reference<unknown>, values: Ts): void;
+
+/**
+ * The default merge functions.
+ */
+declare type MergeFunctions = {
+    mergeRecords: typeof mergeRecords;
+    mergeArrays: typeof mergeArrays;
+    mergeSets: typeof mergeSets;
+    mergeMaps: typeof mergeMaps;
+    mergeOthers: typeof mergeOthers;
+};
+/**
+ * The default strategy to merge records.
+ *
+ * @param values - The records.
+ */
+declare function mergeRecords<Ts extends ReadonlyArray<Record<PropertyKey, unknown>>, U extends DeepMergeMergeFunctionUtils<M, MM>, MF extends DeepMergeMergeFunctionsURIs, M, MM extends DeepMergeBuiltInMetaData = DeepMergeBuiltInMetaData>(values: Ts, utils: U, meta: M | undefined): DeepMergeRecordsDefaultHKT<Ts, MF, M>;
+/**
+ * The default strategy to merge arrays.
+ *
+ * @param values - The arrays.
+ */
+declare function mergeArrays<Ts extends ReadonlyArray<ReadonlyArray<unknown>>, MF extends DeepMergeMergeFunctionsURIs, M>(values: Ts): DeepMergeArraysDefaultHKT<Ts, MF, M>;
+/**
+ * The default strategy to merge sets.
+ *
+ * @param values - The sets.
+ */
+declare function mergeSets<Ts extends ReadonlyArray<Readonly<ReadonlySet<unknown>>>>(values: Ts): DeepMergeSetsDefaultHKT<Ts>;
+/**
+ * The default strategy to merge maps.
+ *
+ * @param values - The maps.
+ */
+declare function mergeMaps<Ts extends ReadonlyArray<Readonly<ReadonlyMap<unknown, unknown>>>>(values: Ts): DeepMergeMapsDefaultHKT<Ts>;
+/**
+ * Get the last value in the given array.
+ */
+declare function mergeOthers<Ts extends ReadonlyArray<unknown>>(values: Ts): unknown;
+
+/**
  * The options the user can pass to customize deepmerge.
  */
-declare type DeepMergeOptions<M, MM extends Readonly<Record<PropertyKey, unknown>> = DeepMergeBuiltInMetaData> = Partial<DeepMergeOptionsFull<M, MM & DeepMergeBuiltInMetaData>>;
-declare type MetaDataUpdater<M, MM extends DeepMergeBuiltInMetaData> = (previousMeta: M | undefined, metaMeta: Readonly<Partial<MM>>) => M;
+declare type DeepMergeOptions<M, MM extends Readonly<Record<PropertyKey, unknown>> = {}> = Partial<DeepMergeOptionsFull<M, MM & DeepMergeBuiltInMetaData>>;
+/**
+ * The options the user can pass to customize deepmergeInto.
+ */
+declare type DeepMergeIntoOptions<M, MM extends Readonly<Record<PropertyKey, unknown>> = {}> = Partial<DeepMergeIntoOptionsFull<M, MM & DeepMergeBuiltInMetaData>>;
+declare type MetaDataUpdater<M, MM extends DeepMergeBuiltInMetaData = DeepMergeBuiltInMetaData> = (previousMeta: M | undefined, metaMeta: Readonly<Partial<MM>>) => M;
 /**
  * All the options the user can pass to customize deepmerge.
  */
-declare type DeepMergeOptionsFull<M, MM extends DeepMergeBuiltInMetaData> = Readonly<{
+declare type DeepMergeOptionsFull<M, MM extends DeepMergeBuiltInMetaData = DeepMergeBuiltInMetaData> = Readonly<{
     mergeRecords: DeepMergeMergeFunctions<M, MM>["mergeRecords"] | false;
     mergeArrays: DeepMergeMergeFunctions<M, MM>["mergeArrays"] | false;
     mergeMaps: DeepMergeMergeFunctions<M, MM>["mergeMaps"] | false;
@@ -321,21 +413,49 @@ declare type DeepMergeOptionsFull<M, MM extends DeepMergeBuiltInMetaData> = Read
     enableImplicitDefaultMerging: boolean;
 }>;
 /**
+ * All the options the user can pass to customize deepmergeInto.
+ */
+declare type DeepMergeIntoOptionsFull<M, MM extends DeepMergeBuiltInMetaData = DeepMergeBuiltInMetaData> = Readonly<{
+    mergeRecords: DeepMergeMergeIntoFunctions<M, MM>["mergeRecords"] | false;
+    mergeArrays: DeepMergeMergeIntoFunctions<M, MM>["mergeArrays"] | false;
+    mergeMaps: DeepMergeMergeIntoFunctions<M, MM>["mergeMaps"] | false;
+    mergeSets: DeepMergeMergeIntoFunctions<M, MM>["mergeSets"] | false;
+    mergeOthers: DeepMergeMergeIntoFunctions<M, MM>["mergeOthers"];
+    metaDataUpdater: MetaDataUpdater<M, MM>;
+}>;
+/**
+ * An object that has a reference to a value.
+ */
+declare type Reference<T> = {
+    value: T;
+};
+/**
  * All the merge functions that deepmerge uses.
  */
-declare type DeepMergeMergeFunctions<M, MM extends DeepMergeBuiltInMetaData> = Readonly<{
-    mergeRecords: <Ts extends ReadonlyArray<Readonly<Record<PropertyKey, unknown>>>, U extends DeepMergeMergeFunctionUtils<M, MM>>(records: Ts, utils: U, meta: M | undefined) => unknown;
-    mergeArrays: <Ts extends ReadonlyArray<ReadonlyArray<unknown>>, U extends DeepMergeMergeFunctionUtils<M, MM>>(records: Ts, utils: U, meta: M | undefined) => unknown;
-    mergeMaps: <Ts extends ReadonlyArray<Readonly<ReadonlyMap<unknown, unknown>>>, U extends DeepMergeMergeFunctionUtils<M, MM>>(records: Ts, utils: U, meta: M | undefined) => unknown;
-    mergeSets: <Ts extends ReadonlyArray<Readonly<ReadonlySet<unknown>>>, U extends DeepMergeMergeFunctionUtils<M, MM>>(records: Ts, utils: U, meta: M | undefined) => unknown;
-    mergeOthers: <Ts extends ReadonlyArray<unknown>, U extends DeepMergeMergeFunctionUtils<M, MM>>(records: Ts, utils: U, meta: M | undefined) => unknown;
+declare type DeepMergeMergeFunctions<in M, MM extends DeepMergeBuiltInMetaData = DeepMergeBuiltInMetaData> = Readonly<{
+    mergeRecords: <Ts extends ReadonlyArray<Readonly<Record<PropertyKey, unknown>>>, U extends DeepMergeMergeFunctionUtils<M, MM>>(values: Ts, utils: U, meta: M | undefined) => unknown;
+    mergeArrays: <Ts extends ReadonlyArray<ReadonlyArray<unknown>>, U extends DeepMergeMergeFunctionUtils<M, MM>>(values: Ts, utils: U, meta: M | undefined) => unknown;
+    mergeMaps: <Ts extends ReadonlyArray<Readonly<ReadonlyMap<unknown, unknown>>>, U extends DeepMergeMergeFunctionUtils<M, MM>>(values: Ts, utils: U, meta: M | undefined) => unknown;
+    mergeSets: <Ts extends ReadonlyArray<Readonly<ReadonlySet<unknown>>>, U extends DeepMergeMergeFunctionUtils<M, MM>>(values: Ts, utils: U, meta: M | undefined) => unknown;
+    mergeOthers: <Ts extends ReadonlyArray<unknown>, U extends DeepMergeMergeFunctionUtils<M, MM>>(values: Ts, utils: U, meta: M | undefined) => unknown;
+}>;
+declare type DeepMergeMergeIntoFunctionsReturnType = void | symbol;
+/**
+ * All the merge functions that deepmerge uses.
+ */
+declare type DeepMergeMergeIntoFunctions<in M, MM extends DeepMergeBuiltInMetaData = DeepMergeBuiltInMetaData> = Readonly<{
+    mergeRecords: <Ts extends ReadonlyArray<Readonly<Record<PropertyKey, unknown>>>, U extends DeepMergeMergeIntoFunctionUtils<M, MM>>(m_target: Reference<Record<PropertyKey, unknown>>, values: Ts, utils: U, meta: M | undefined) => DeepMergeMergeIntoFunctionsReturnType;
+    mergeArrays: <Ts extends ReadonlyArray<ReadonlyArray<unknown>>, U extends DeepMergeMergeIntoFunctionUtils<M, MM>>(m_target: Reference<unknown[]>, values: Ts, utils: U, meta: M | undefined) => DeepMergeMergeIntoFunctionsReturnType;
+    mergeMaps: <Ts extends ReadonlyArray<Readonly<ReadonlyMap<unknown, unknown>>>, U extends DeepMergeMergeIntoFunctionUtils<M, MM>>(m_target: Reference<Map<unknown, unknown>>, values: Ts, utils: U, meta: M | undefined) => DeepMergeMergeIntoFunctionsReturnType;
+    mergeSets: <Ts extends ReadonlyArray<Readonly<ReadonlySet<unknown>>>, U extends DeepMergeMergeIntoFunctionUtils<M, MM>>(m_target: Reference<Set<unknown>>, values: Ts, utils: U, meta: M | undefined) => DeepMergeMergeIntoFunctionsReturnType;
+    mergeOthers: <Ts extends ReadonlyArray<unknown>, U extends DeepMergeMergeIntoFunctionUtils<M, MM>>(m_target: Reference<unknown>, values: Ts, utils: U, meta: M | undefined) => DeepMergeMergeIntoFunctionsReturnType;
 }>;
 /**
  * The utils provided to the merge functions.
  */
-declare type DeepMergeMergeFunctionUtils<M, MM extends DeepMergeBuiltInMetaData> = Readonly<{
+declare type DeepMergeMergeFunctionUtils<M, MM extends DeepMergeBuiltInMetaData = DeepMergeBuiltInMetaData> = Readonly<{
     mergeFunctions: DeepMergeMergeFunctions<M, MM>;
-    defaultMergeFunctions: DeepMergeMergeFunctionsDefaults;
+    defaultMergeFunctions: MergeFunctions;
     metaDataUpdater: MetaDataUpdater<M, MM>;
     deepmerge: <Ts extends ReadonlyArray<unknown>>(...values: Ts) => unknown;
     useImplicitDefaultMerging: boolean;
@@ -344,18 +464,19 @@ declare type DeepMergeMergeFunctionUtils<M, MM extends DeepMergeBuiltInMetaData>
         skip: symbol;
     }>;
 }>;
-
-declare const defaultMergeFunctions: {
-    readonly mergeMaps: typeof defaultMergeMaps;
-    readonly mergeSets: typeof defaultMergeSets;
-    readonly mergeArrays: typeof defaultMergeArrays;
-    readonly mergeRecords: typeof defaultMergeRecords;
-    readonly mergeOthers: typeof leaf;
-};
 /**
- * The default merge functions.
+ * The utils provided to the merge functions.
  */
-declare type DeepMergeMergeFunctionsDefaults = typeof defaultMergeFunctions;
+declare type DeepMergeMergeIntoFunctionUtils<M, MM extends DeepMergeBuiltInMetaData = DeepMergeBuiltInMetaData> = Readonly<{
+    mergeFunctions: DeepMergeMergeIntoFunctions<M, MM>;
+    defaultMergeFunctions: MergeFunctions$1;
+    metaDataUpdater: MetaDataUpdater<M, MM>;
+    deepmergeInto: <Target extends object, Ts extends ReadonlyArray<unknown>>(target: Target, ...values: Ts) => void;
+    actions: Readonly<{
+        defaultMerge: symbol;
+    }>;
+}>;
+
 /**
  * Deeply merge objects.
  *
@@ -367,41 +488,44 @@ declare function deepmerge<Ts extends Readonly<ReadonlyArray<unknown>>>(...objec
  *
  * @param options - The options on how to customize the merge function.
  */
-declare function deepmergeCustom<PMF extends Partial<DeepMergeMergeFunctionsURIs>>(options: DeepMergeOptions<DeepMergeBuiltInMetaData, DeepMergeBuiltInMetaData>): <Ts extends ReadonlyArray<unknown>>(...objects: Ts) => DeepMergeHKT<Ts, GetDeepMergeMergeFunctionsURIs<PMF>, DeepMergeBuiltInMetaData>;
+declare function deepmergeCustom<BaseTs = unknown, PMF extends Partial<DeepMergeMergeFunctionsURIs> = {}>(options: DeepMergeOptions<DeepMergeBuiltInMetaData, DeepMergeBuiltInMetaData>): <Ts extends ReadonlyArray<BaseTs>>(...objects: Ts) => DeepMergeHKT<Ts, GetDeepMergeMergeFunctionsURIs<PMF>, DeepMergeBuiltInMetaData>;
 /**
  * Deeply merge two or more objects using the given options and meta data.
  *
  * @param options - The options on how to customize the merge function.
  * @param rootMetaData - The meta data passed to the root items' being merged.
  */
-declare function deepmergeCustom<PMF extends Partial<DeepMergeMergeFunctionsURIs>, MetaData, MetaMetaData extends DeepMergeBuiltInMetaData = DeepMergeBuiltInMetaData>(options: DeepMergeOptions<MetaData, MetaMetaData>, rootMetaData?: MetaData): <Ts extends ReadonlyArray<unknown>>(...objects: Ts) => DeepMergeHKT<Ts, GetDeepMergeMergeFunctionsURIs<PMF>, MetaData>;
-/**
- * The default strategy to merge records.
- *
- * @param values - The records.
- */
-declare function defaultMergeRecords<Ts extends ReadonlyArray<Record<PropertyKey, unknown>>, U extends DeepMergeMergeFunctionUtils<M, MM>, MF extends DeepMergeMergeFunctionsURIs, M, MM extends DeepMergeBuiltInMetaData>(values: Ts, utils: U, meta: M | undefined): DeepMergeRecordsDefaultHKT<Ts, MF, M>;
-/**
- * The default strategy to merge arrays.
- *
- * @param values - The arrays.
- */
-declare function defaultMergeArrays<Ts extends ReadonlyArray<ReadonlyArray<unknown>>, MF extends DeepMergeMergeFunctionsURIs, M>(values: Ts): DeepMergeArraysDefaultHKT<Ts, MF, M>;
-/**
- * The default strategy to merge sets.
- *
- * @param values - The sets.
- */
-declare function defaultMergeSets<Ts extends ReadonlyArray<Readonly<ReadonlySet<unknown>>>>(values: Ts): DeepMergeSetsDefaultHKT<Ts>;
-/**
- * The default strategy to merge maps.
- *
- * @param values - The maps.
- */
-declare function defaultMergeMaps<Ts extends ReadonlyArray<Readonly<ReadonlyMap<unknown, unknown>>>>(values: Ts): DeepMergeMapsDefaultHKT<Ts>;
-/**
- * Get the last value in the given array.
- */
-declare function leaf<Ts extends ReadonlyArray<unknown>>(values: Ts): unknown;
+declare function deepmergeCustom<BaseTs = unknown, PMF extends Partial<DeepMergeMergeFunctionsURIs> = {}, MetaData = DeepMergeBuiltInMetaData, MetaMetaData extends DeepMergeBuiltInMetaData = DeepMergeBuiltInMetaData>(options: DeepMergeOptions<MetaData, MetaMetaData>, rootMetaData?: MetaData): <Ts extends ReadonlyArray<BaseTs>>(...objects: Ts) => DeepMergeHKT<Ts, GetDeepMergeMergeFunctionsURIs<PMF>, MetaData>;
 
-export { DeepMergeArraysDefaultHKT, DeepMergeBuiltInMetaData, DeepMergeHKT, DeepMergeLeaf, DeepMergeLeafHKT, DeepMergeLeafURI, DeepMergeMapsDefaultHKT, DeepMergeMergeFunctionURItoKind, DeepMergeMergeFunctionUtils, DeepMergeMergeFunctionsDefaultURIs, DeepMergeMergeFunctionsDefaults, DeepMergeMergeFunctionsURIs, DeepMergeOptions, DeepMergeRecordsDefaultHKT, DeepMergeSetsDefaultHKT, deepmerge, deepmergeCustom };
+/**
+ * Deeply merge objects into a target.
+ *
+ * @param target - This object will be mutated with the merge result.
+ * @param objects - The objects to merge into the target.
+ */
+declare function deepmergeInto<T extends object>(target: T, ...objects: ReadonlyArray<T>): void;
+/**
+ * Deeply merge objects into a target.
+ *
+ * @param target - This object will be mutated with the merge result.
+ * @param objects - The objects to merge into the target.
+ */
+declare function deepmergeInto<Target extends object, Ts extends ReadonlyArray<unknown>>(target: Target, ...objects: Ts): asserts target is FlatternAlias<Target & DeepMergeHKT<[
+    Target,
+    ...Ts
+], DeepMergeMergeFunctionsDefaultURIs, DeepMergeBuiltInMetaData>>;
+/**
+ * Deeply merge two or more objects using the given options.
+ *
+ * @param options - The options on how to customize the merge function.
+ */
+declare function deepmergeIntoCustom<BaseTs = unknown>(options: DeepMergeIntoOptions<DeepMergeBuiltInMetaData, DeepMergeBuiltInMetaData>): <Target extends object, Ts extends ReadonlyArray<BaseTs>>(target: Target, ...objects: Ts) => void;
+/**
+ * Deeply merge two or more objects using the given options and meta data.
+ *
+ * @param options - The options on how to customize the merge function.
+ * @param rootMetaData - The meta data passed to the root items' being merged.
+ */
+declare function deepmergeIntoCustom<BaseTs = unknown, MetaData = DeepMergeBuiltInMetaData, MetaMetaData extends DeepMergeBuiltInMetaData = DeepMergeBuiltInMetaData>(options: DeepMergeIntoOptions<MetaData, MetaMetaData>, rootMetaData?: MetaData): <Target extends object, Ts extends ReadonlyArray<BaseTs>>(target: Target, ...objects: Ts) => void;
+
+export { DeepMergeArraysDefaultHKT, DeepMergeBuiltInMetaData, DeepMergeHKT, DeepMergeIntoOptions, DeepMergeLeaf, DeepMergeLeafHKT, DeepMergeLeafURI, DeepMergeMapsDefaultHKT, DeepMergeMergeFunctionURItoKind, DeepMergeMergeFunctionUtils, DeepMergeMergeFunctionsDefaultURIs, MergeFunctions as DeepMergeMergeFunctionsDefaults, DeepMergeMergeFunctionsURIs, DeepMergeMergeIntoFunctionUtils, MergeFunctions$1 as DeepMergeMergeIntoFunctionsDefaults, DeepMergeOptions, DeepMergeRecordsDefaultHKT, DeepMergeSetsDefaultHKT, Reference as DeepMergeValueReference, deepmerge, deepmergeCustom, deepmergeInto, deepmergeIntoCustom };


### PR DESCRIPTION
BREAKING CHANGE: The order of the generics of `deepmergeCustom` and `deepmergeIntoCustom` have changed. If you are passing generics to these functions you need to update them.

fix #305