### PR TITLE
feat(benchmark): add `defu` to compare with

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "deepmerge": "^4.3.1",
     "deepmerge-ts": "link:..",
+    "defu": "^6.1.4",
     "lodash": "^4.17.21",
     "merge-anything": "^5.1.7",
     "object-accumulator": "^0.0.5"

--- a/benchmark/pnpm-lock.yaml
+++ b/benchmark/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       deepmerge-ts:
         specifier: link:..
         version: link:..
+      defu:
+        specifier: ^6.1.4
+        version: 6.1.4
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -184,6 +187,9 @@ packages:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
 
+  defu@6.1.4:
+    resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+
   esbuild@0.20.2:
     resolution: {integrity: sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==}
     engines: {node: '>=12'}
@@ -306,6 +312,8 @@ snapshots:
       undici-types: 5.26.5
 
   deepmerge@4.3.1: {}
+
+  defu@6.1.4: {}
 
   esbuild@0.20.2:
     optionalDependencies:

--- a/benchmark/run.ts
+++ b/benchmark/run.ts
@@ -76,7 +76,7 @@ for (let m_i = 0; m_i < benchmarkDataSets.length; m_i++) {
       deepmerge.all(benchmarkData);
     })
     .add("defu", () => {
-      defu(benchmarkData);
+      defu({}, ...benchmarkData);
     })
     .add("merge-anything", () => {
       (mergeAnything as any)(...benchmarkData);

--- a/benchmark/run.ts
+++ b/benchmark/run.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 
 import deepmerge from "deepmerge";
 import { deepmerge as deepmergeTs } from "deepmerge-ts";
+import { defu } from "defu";
 import lodash from "lodash";
 import { merge as mergeAnything } from "merge-anything";
 import { Accumulator as ObjectAccumulator } from "object-accumulator";
@@ -73,6 +74,9 @@ for (let m_i = 0; m_i < benchmarkDataSets.length; m_i++) {
     })
     .add("deepmerge", () => {
       deepmerge.all(benchmarkData);
+    })
+    .add("defu", () => {
+      defu(benchmarkData);
     })
     .add("merge-anything", () => {
       (mergeAnything as any)(...benchmarkData);

--- a/project-dictionary.txt
+++ b/project-dictionary.txt
@@ -8,6 +8,7 @@ deassert
 deepmerge
 deepmergecustomoptions
 deepmergets
+defu
 denoify
 foo
 fred


### PR DESCRIPTION
Hi @RebeccaStevens 👋!

I hope I am not bringing a bad news with this PR, nor any negative feelings!

I've created a [PR on Storybook](https://github.com/storybookjs/storybook/pull/28663), where I am trying to replace `lodash/merge` and `lodash/mergeWith` with an alternative.\
Initially I thought of your package, because it was the only one I knew so far.

Until I learned about [`defu`].

Naturally, I had answer one of question - performance. You have done an outstanding work on this package, because you have benchmarks, where it was easy to add `defu` to compare with.

[`defu`]: https://github.com/unjs/defu

It looks like `defu` wins with a big margin, but I am giving a benefit of the doubt to know if my benchmark setup is wrong, or I am missing something.

## Results

**Device**: MacBook Pro M2

<details>
<summary>Results during invalid usage - before fix</summary>

```txt
No benchmark data file found. Generating random data for benchmarking against.

Running benchmarks for data set "tall" (1 of 3):

┌─────────┬──────────────────────┬─────────────┬────────────────────┬──────────┬──────────┐
│ (index) │ Task Name            │ ops/sec     │ Average Time (ns)  │ Margin   │ Samples  │
├─────────┼──────────────────────┼─────────────┼────────────────────┼──────────┼──────────┤
│ 0       │ 'deepmerge-ts'       │ '527,615'   │ 1895.3208846141354 │ '±0.19%' │ 5276152  │
│ 1       │ 'deepmerge'          │ '3'         │ 289569472.22222215 │ '±4.69%' │ 36       │
│ 2       │ 'defu'               │ '6,208,484' │ 161.06991183128463 │ '±0.05%' │ 62084842 │
│ 3       │ 'merge-anything'     │ '664,669'   │ 1504.507973736976  │ '±0.52%' │ 6646692  │
│ 4       │ 'object-accumulator' │ '9'         │ 106072233.74736802 │ '±4.88%' │ 95       │
│ 5       │ 'lodash merge'       │ '4'         │ 205049445.46938705 │ '±1.56%' │ 49       │
└─────────┴──────────────────────┴─────────────┴────────────────────┴──────────┴──────────┘

Running benchmarks for data set "wide" (2 of 3):

┌─────────┬──────────────────────┬─────────────┬────────────────────┬───────────┬──────────┐
│ (index) │ Task Name            │ ops/sec     │ Average Time (ns)  │ Margin    │ Samples  │
├─────────┼──────────────────────┼─────────────┼────────────────────┼───────────┼──────────┤
│ 0       │ 'deepmerge-ts'       │ '2'         │ 425422401.000001   │ '±2.76%'  │ 24       │
│ 1       │ 'deepmerge'          │ '0'         │ 9545288958.50001   │ '±55.55%' │ 2        │
│ 2       │ 'defu'               │ '6,210,981' │ 161.00515641617744 │ '±0.26%'  │ 62109813 │
│ 3       │ 'merge-anything'     │ '1'         │ 921586829.5454526  │ '±0.23%'  │ 11       │
│ 4       │ 'object-accumulator' │ '177'       │ 5641003.027636446  │ '±1.22%'  │ 1773     │
│ 5       │ 'lodash merge'       │ '1'         │ 648883515.5000015  │ '±1.00%'  │ 16       │
└─────────┴──────────────────────┴─────────────┴────────────────────┴───────────┴──────────┘

Running benchmarks for data set "mid" (3 of 3):

┌─────────┬──────────────────────┬─────────────┬────────────────────┬──────────┬──────────┐
│ (index) │ Task Name            │ ops/sec     │ Average Time (ns)  │ Margin   │ Samples  │
├─────────┼──────────────────────┼─────────────┼────────────────────┼──────────┼──────────┤
│ 0       │ 'deepmerge-ts'       │ '23'        │ 41874533.28451813  │ '±0.49%' │ 239      │
│ 1       │ 'deepmerge'          │ '0'         │ 2443575399.9999957 │ '±2.27%' │ 5        │
│ 2       │ 'defu'               │ '5,881,482' │ 170.02515962682915 │ '±0.66%' │ 58814826 │
│ 3       │ 'merge-anything'     │ '28'        │ 35619074.024909645 │ '±0.42%' │ 281      │
│ 4       │ 'object-accumulator' │ '150'       │ 6660438.356858103  │ '±1.70%' │ 1502     │
│ 5       │ 'lodash merge'       │ '2'         │ 377150435.29629904 │ '±0.40%' │ 27       │
└─────────┴──────────────────────┴─────────────┴────────────────────┴──────────┴──────────┘
```
</details>

<details>
<summary>Results after the possible fix</summary>

```txt
Loading benchmark data file.

Running benchmarks for data set "tall" (1 of 3):

┌─────────┬──────────────────────┬─────────────┬────────────────────┬──────────┬──────────┐
│ (index) │ Task Name            │ ops/sec     │ Average Time (ns)  │ Margin   │ Samples  │
├─────────┼──────────────────────┼─────────────┼────────────────────┼──────────┼──────────┤
│ 0       │ 'deepmerge-ts'       │ '517,389'   │ 1932.7816774650069 │ '±0.28%' │ 5173891  │
│ 1       │ 'deepmerge'          │ '3'         │ 283752828.8611113  │ '±3.94%' │ 36       │
│ 2       │ 'defu'               │ '1,116,263' │ 895.8455933085199  │ '±0.27%' │ 11162638 │
│ 3       │ 'merge-anything'     │ '690,933'   │ 1447.316283031864  │ '±0.26%' │ 6909340  │
│ 4       │ 'object-accumulator' │ '9'         │ 101954385.53535335 │ '±1.49%' │ 99       │
│ 5       │ 'lodash merge'       │ '5'         │ 192098338.07547063 │ '±0.39%' │ 53       │
└─────────┴──────────────────────┴─────────────┴────────────────────┴──────────┴──────────┘

Running benchmarks for data set "wide" (2 of 3):

┌─────────┬──────────────────────┬─────────┬────────────────────┬───────────┬─────────┐
│ (index) │ Task Name            │ ops/sec │ Average Time (ns)  │ Margin    │ Samples │
├─────────┼──────────────────────┼─────────┼────────────────────┼───────────┼─────────┤
│ 0       │ 'deepmerge-ts'       │ '2'     │ 403044879.9999984  │ '±0.09%'  │ 25      │
│ 1       │ 'deepmerge'          │ '0'     │ 10142960707.999985 │ '±0.00%'  │ 1       │
│ 2       │ 'defu'               │ '2'     │ 412902348.2400016  │ '±3.19%'  │ 25      │
│ 3       │ 'merge-anything'     │ '1'     │ 951229765.0909168  │ '±11.77%' │ 11      │
│ 4       │ 'object-accumulator' │ '177'   │ 5644815.621895985  │ '±1.92%'  │ 1772    │
│ 5       │ 'lodash merge'       │ '1'     │ 618995225.4117645  │ '±2.30%'  │ 17      │
└─────────┴──────────────────────┴─────────┴────────────────────┴───────────┴─────────┘

Running benchmarks for data set "mid" (3 of 3):

┌─────────┬──────────────────────┬─────────┬────────────────────┬──────────┬─────────┐
│ (index) │ Task Name            │ ops/sec │ Average Time (ns)  │ Margin   │ Samples │
├─────────┼──────────────────────┼─────────┼────────────────────┼──────────┼─────────┤
│ 0       │ 'deepmerge-ts'       │ '23'    │ 42636126.81276876  │ '±1.98%' │ 235     │
│ 1       │ 'deepmerge'          │ '0'     │ 2439054750.0000043 │ '±1.43%' │ 5       │
│ 2       │ 'defu'               │ '64'    │ 15539177.942545502 │ '±0.45%' │ 644     │
│ 3       │ 'merge-anything'     │ '26'    │ 37383370.03731453  │ '±2.42%' │ 268     │
│ 4       │ 'object-accumulator' │ '154'   │ 6478492.177460992  │ '±0.12%' │ 1544    │
│ 5       │ 'lodash merge'       │ '2'     │ 386707298.0384613  │ '±3.00%' │ 26      │
└─────────┴──────────────────────┴─────────┴────────────────────┴──────────┴─────────┘
```

</details>

While Storybook has just a simple need for `merge`. I still want to give your package a chance. Do you think there's any other reason you believe they should favour your package over `defu`?